### PR TITLE
CredentialBuilder sample

### DIFF
--- a/CredentialBuilderSample/Program.cs
+++ b/CredentialBuilderSample/Program.cs
@@ -1,4 +1,11 @@
-﻿namespace Genetec.Dap.CodeSamples
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+namespace Genetec.Dap.CodeSamples
 {
     using System;
     using System.Collections.Generic;
@@ -89,9 +96,7 @@
                 }
                 else
                 {
-                    credentialBuilder.SetName(name);
-                    credentialBuilder.SetFormat(format);
-                    credential = credentialBuilder.Build();
+                    credential = credentialBuilder.SetName(name).SetFormat(format).Build();
                 }
 
                 DisplayCredentialDetails(credential);


### PR DESCRIPTION
Streamlined the instantiation of `credential` object by chaining `SetName` and `SetFormat` methods before calling `Build`, enhancing code readability and conciseness.