### PR TITLE
VisitorManager sample

### DIFF
--- a/VisitorManagerSample/Program.cs
+++ b/VisitorManagerSample/Program.cs
@@ -146,7 +146,7 @@ namespace Genetec.Dap.CodeSamples
                 VisitDate = row.Field<DateTime>("VisitDate"),
                 MobilePhoneNumber = row.Field<string>("MobilePhoneNumber"),
                 VisitorState = row.Field<VisitorState>("VisitorState"),
-            }).Last();
+            }).LastOrDefault();
         }
 
         static void DisplayArchivedVisitorInfo(ArchivedVisitor archivedVisitor)


### PR DESCRIPTION
Bug fix to handle empty collections more gracefully.

The code change replaces `Last()` with `LastOrDefault()` to prevent exceptions when collections are empty.
