### PR TITLE
AccessControlReportQuery sample

### DIFF
--- a/AccessControlReportQuerySample/Program.cs
+++ b/AccessControlReportQuerySample/Program.cs
@@ -141,8 +141,4 @@ class AccessControlEvent
     public TimeZoneInfo TimeZone { get; set; }
     public OfflinePeriodType OccurrencePeriod { get; set; }
     public Guid? Cardholder { get; set; }
-    string GetEntityName(Engine engine, Guid? entityId)
-    {
-        return engine.GetEntity(entityId.GetValueOrDefault())?.Name;
-    }
 }


### PR DESCRIPTION
The GetEntityName method, which took an Engine object and a
nullable Guid as parameters and returned the name of the entity
associated with the provided Guid, has been removed from the
AccessControlEvent class.