### PR TITLE
ConfigPage sample

### DIFF
--- a/ConfigPageSample/AedUnitCustomEntityType.cs
+++ b/ConfigPageSample/AedUnitCustomEntityType.cs
@@ -1,9 +1,17 @@
-﻿namespace Genetec.Dap.CodeSamples
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+namespace Genetec.Dap.CodeSamples
 {
     using System;
 
+    // TODO: Update the GUID in this class with your own custom entity type ID
     public static class AedUnitCustomEntityType
     {
-        public static Guid Id { get; } = new Guid("8385D04C-F04A-4125-81E9-D1C66AFDE572");
+        public static Guid Id { get; } = new("8385D04C-F04A-4125-81E9-D1C66AFDE572");
     }
 }

--- a/ConfigPageSample/AedUnitCustomPrivilege.cs
+++ b/ConfigPageSample/AedUnitCustomPrivilege.cs
@@ -1,19 +1,24 @@
-﻿// Copyright (C) 2024 by Genetec, Inc. All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 namespace Genetec.Dap.CodeSamples
 {
     using System;
     using Sdk;
 
+    // TODO: Update the GUIDs in this class with your own SDK privilege IDs
     public static class AedUnitCustomPrivilege
     {
-        public static SdkPrivilege View { get; } = new SdkPrivilege(new Guid("0896B350-7225-4A53-8DDC-E8365CAE456E"));
+        public static SdkPrivilege View { get; } = new(new Guid("0896B350-7225-4A53-8DDC-E8365CAE456E"));
 
-        public static SdkPrivilege Modify { get; } = new SdkPrivilege(new Guid("1938B316-B651-43B7-96B1-B94C3FDBB756"));
+        public static SdkPrivilege Modify { get; } = new(new Guid("1938B316-B651-43B7-96B1-B94C3FDBB756"));
 
-        public static SdkPrivilege Add { get; } = new SdkPrivilege(new Guid("0707B77A-1091-4AEB-877E-30EAA80E9626"));
+        public static SdkPrivilege Add { get; } = new(new Guid("0707B77A-1091-4AEB-877E-30EAA80E9626"));
 
-        public static SdkPrivilege Delete { get; } = new SdkPrivilege(new Guid("6008ECEB-024F-4D4C-BC54-0B8BC8C58D5B"));
+        public static SdkPrivilege Delete { get; } = new(new Guid("6008ECEB-024F-4D4C-BC54-0B8BC8C58D5B"));
     }
 }

--- a/ConfigPageSample/AedUnitInformation.cs
+++ b/ConfigPageSample/AedUnitInformation.cs
@@ -1,5 +1,9 @@
-﻿// Copyright (C) 2024 by Genetec, Inc. All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 namespace Genetec.Dap.CodeSamples
 {
@@ -11,42 +15,41 @@ namespace Genetec.Dap.CodeSamples
     [DataContract(Namespace = "")]
     public class AedUnitInformation
     {
-        [DataMember]
+        private static readonly DataContractSerializer s_serializer = new(typeof(AedUnitInformation));
+
+        [DataMember] 
         public DateTime LastInspectionDate { get; set; }
 
-        [DataMember]
+        [DataMember] 
         public DateTime NextScheduledMaintenance { get; set; }
 
-        [DataMember]
+        [DataMember] 
         public DateTime BatteryExpirationDate { get; set; }
 
-        [DataMember]
+        [DataMember] 
         public DateTime PadExpirationDate { get; set; }
 
-        private static readonly DataContractSerializer s_serializer = new DataContractSerializer(typeof(AedUnitInformation));
-
+        // Deserialize the data from an XML string
         public static AedUnitInformation Deserialize(string data)
         {
             if (string.IsNullOrEmpty(data))
+            {
                 return new AedUnitInformation();
+            }
 
             using var stringReader = new StringReader(data);
             using var xmlReader = XmlReader.Create(stringReader);
             return (AedUnitInformation)s_serializer.ReadObject(xmlReader);
         }
 
+        // Serialize the data to an XML string
         public string Serialize()
         {
-            using (var stringWriter = new StringWriter())
-            {
-                using (var xmlWriter = XmlWriter.Create(stringWriter))
-                {
-                    s_serializer.WriteObject(xmlWriter, this);
-                    xmlWriter.Flush();
-                    return stringWriter.ToString();
-                }
-            }
+            using var stringWriter = new StringWriter();
+            using var xmlWriter = XmlWriter.Create(stringWriter);
+            s_serializer.WriteObject(xmlWriter, this);
+            xmlWriter.Flush();
+            return stringWriter.ToString();
         }
     }
-
 }

--- a/ConfigPageSample/CustomConfigPage.cs
+++ b/ConfigPageSample/CustomConfigPage.cs
@@ -1,42 +1,54 @@
-﻿// Copyright (C) 2024 by Genetec, Inc. All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 namespace Genetec.Dap.CodeSamples
 {
     using System;
     using System.Runtime.CompilerServices;
+    using System.Windows.Media;
     using Sdk;
     using Sdk.Entities;
     using Sdk.Workspace.Pages;
 
     internal class CustomConfigPage : ConfigPage
     {
-        private CustomEntity m_customEntity;
-
-        private DateTime m_padExpirationDate;
-
         private DateTime m_batteryExpirationDate;
 
-        private DateTime m_nextScheduledMaintenance;
+        private CustomEntity m_customEntity;
 
         private DateTime m_lastInspectionDate;
 
+        private DateTime m_nextScheduledMaintenance;
+
+        private DateTime m_padExpirationDate;
+
+        // Specify for which entity type this configuration page is intended
         protected override EntityType EntityType => EntityType.CustomEntity;
 
         protected override Guid Entity
         {
             set
             {
-                if (Workspace.Sdk.GetEntity(value) is CustomEntity entity && entity.CustomEntityType == new Guid("8385D04C-F04A-4125-81E9-D1C66AFDE572"))
+                // Check if the entity is a custom entity of the expected type
+                if (Workspace.Sdk.GetEntity(value) is CustomEntity entity && entity.CustomEntityType == AedUnitCustomEntityType.Id)
                 {
-                    m_customEntity = entity;
-                    IsVisible = true;
+                    m_customEntity = entity; // Store the entity
+                    IsVisible = true; // Show the configuration page
                 }
                 else
                 {
-                    IsVisible = false;
+                    IsVisible = false; // Hide the configuration page
                 }
             }
+        }
+
+        // A public default constructor is required
+        public CustomConfigPage()
+        {
         }
 
         public DateTime LastInspectionDate
@@ -46,7 +58,7 @@ namespace Genetec.Dap.CodeSamples
             {
                 if (SetProperty(ref m_lastInspectionDate, value))
                 {
-                    IsDirty = true;
+                    IsDirty = true; // Mark the configuration as dirty, triggering the Save button to be enabled
                 }
             }
         }
@@ -58,7 +70,7 @@ namespace Genetec.Dap.CodeSamples
             {
                 if (SetProperty(ref m_nextScheduledMaintenance, value))
                 {
-                    IsDirty = true;
+                    IsDirty = true; // Mark the configuration as dirty, triggering the Save button to be enabled
                 }
             }
         }
@@ -70,7 +82,7 @@ namespace Genetec.Dap.CodeSamples
             {
                 if (SetProperty(ref m_batteryExpirationDate, value))
                 {
-                    IsDirty = true;
+                    IsDirty = true; // Mark the configuration as dirty, triggering the Save button to be enabled
                 }
             }
         }
@@ -82,10 +94,14 @@ namespace Genetec.Dap.CodeSamples
             {
                 if (SetProperty(ref m_padExpirationDate, value))
                 {
-                    IsDirty = true;
+                    IsDirty = true; // Mark the configuration as dirty, triggering the Save button to be enabled
                 }
             }
         }
+
+        protected override string Name => base.Name; // Optional: The name of the configuration page. Default is "Properties".
+
+        protected override ImageSource Image => base.Image; // Optional: The image of the configuration page. Default is the "Properties" image.
 
         private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
@@ -102,9 +118,10 @@ namespace Genetec.Dap.CodeSamples
 
         protected override void Initialize()
         {
-            View = new CustomConfigPageView { DataContext = this };
+            View = new CustomConfigPageView { DataContext = this }; // Assign the view to the config page and associate it with this view model
         }
 
+        // Load the configuration from the custom entity
         protected override void Refresh()
         {
             AedUnitInformation configuration = AedUnitInformation.Deserialize(m_customEntity.Xml);
@@ -115,15 +132,21 @@ namespace Genetec.Dap.CodeSamples
             IsDirty = false;
         }
 
+        // Validate the configuration before saving
+        protected override void BeforeSave(bool beforeUnloading, out bool cancelSaveOperation)
+        {
+            if (NextScheduledMaintenance <= LastInspectionDate)
+            {
+                cancelSaveOperation = true;
+            }
+
+            cancelSaveOperation = false;
+        }
+
+        // Save the configuration to the custom entity
         protected override void Save()
         {
-            m_customEntity.Xml = new AedUnitInformation
-            {
-                LastInspectionDate = LastInspectionDate,
-                NextScheduledMaintenance = NextScheduledMaintenance,
-                BatteryExpirationDate = BatteryExpirationDate,
-                PadExpirationDate = PadExpirationDate
-            }.Serialize();
+            m_customEntity.Xml = new AedUnitInformation { LastInspectionDate = LastInspectionDate, NextScheduledMaintenance = NextScheduledMaintenance, BatteryExpirationDate = BatteryExpirationDate, PadExpirationDate = PadExpirationDate }.Serialize();
         }
     }
 }

--- a/ConfigPageSample/CustomConfigPageView.xaml.cs
+++ b/ConfigPageSample/CustomConfigPageView.xaml.cs
@@ -1,4 +1,11 @@
-﻿namespace Genetec.Dap.CodeSamples
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+namespace Genetec.Dap.CodeSamples
 {
     using System.Windows.Controls;
 

--- a/ConfigPageSample/SampleModule.cs
+++ b/ConfigPageSample/SampleModule.cs
@@ -1,11 +1,16 @@
-﻿// Copyright (C) 2024 by Genetec, Inc. All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 namespace Genetec.Dap.CodeSamples
 {
     using System;
     using System.Collections.Generic;
     using System.Windows.Media.Imaging;
+    using Genetec.Sdk.Privileges;
     using Properties;
     using Sdk;
     using Sdk.Entities;
@@ -16,16 +21,18 @@ namespace Genetec.Dap.CodeSamples
     {
         public override void Load()
         {
-            if (Workspace.ApplicationType == ApplicationType.ConfigTool)
+            if (Workspace.ApplicationType is ApplicationType.ConfigTool)
             {
                 Workspace.Sdk.LoggedOn += (sender, e) =>
                 {
                     if (Workspace.Sdk.LoggedUser.IsAdministrator)
                     {
+                        CreateCustomPrivileges();
                         CreateDeviceCustomEntity();
                     }
                 };
 
+                // Initialize and register the custom configuration page
                 var page = new CustomConfigPage();
                 page.Initialize(Workspace);
                 Workspace.Services.Get<IConfigurationService>().Register(page);
@@ -56,42 +63,87 @@ namespace Genetec.Dap.CodeSamples
                 HierarchicalChildTypes = new List<EntityType> { EntityType.Camera },
                 AuditableProperties = new List<CustomEntityAuditableProperty>
                 {
-                    new CustomEntityAuditableProperty
+                    new()
                     {
                         Hints = AuditPropertyHints.Xml,
                         Name = "Last inspection date",
                         NameKey = "LastInspectionDate",
-                        Path = "/AedUnitInformation/LastInspectionDate",
+                        Path = "AedUnitInformation/LastInspectionDate",
                         SourceProperty = AuditPropertySource.Xml
                     },
-                    new CustomEntityAuditableProperty
+                    new()
                     {
                         Hints = AuditPropertyHints.Xml,
                         Name = "Next scheduled maintenance",
                         NameKey = "NextScheduledMaintenance",
-                        Path = "/AedUnitInformation/NextScheduledMaintenance",
+                        Path = "AedUnitInformation/NextScheduledMaintenance",
                         SourceProperty = AuditPropertySource.Xml
                     },
-                    new CustomEntityAuditableProperty
+                    new()
                     {
                         Hints = AuditPropertyHints.Xml,
                         Name = "Battery expiration date",
                         NameKey = "BatteryExpirationDate",
-                        Path = "/AedUnitInformation/BatteryExpirationDate",
+                        Path = "AedUnitInformation/BatteryExpirationDate",
                         SourceProperty = AuditPropertySource.Xml
                     },
-                    new CustomEntityAuditableProperty
+                    new()
                     {
                         Hints = AuditPropertyHints.Xml,
                         Name = "Pad expiration date",
                         NameKey = "PadExpirationDate",
-                        Path = "/AedUnitInformation/PadExpirationDate",
+                        Path = "AedUnitInformation/PadExpirationDate",
                         SourceProperty = AuditPropertySource.Xml
                     }
                 }
             };
 
             config.AddOrUpdateCustomEntityType(descriptor);
+        }
+
+        private void CreateCustomPrivileges()
+        {
+            Guid privilegeGroupId = Guid.Parse("864E018E-8B50-41B7-80F5-4F1BB2BBED6E");
+
+            Workspace.Sdk.SecurityManager.RegisterPrivileges(new List<PrivilegeRegistration>
+            {
+                new(id: privilegeGroupId,
+                    type: PrivilegeType.Group,
+                    description: "AED Unit",
+                    details: "AED Unit",
+                    priority: 2,
+                    icon: null,
+                    parentId: Guid.Parse("38ACC600-4A32-44ff-8DF5-0797D888930B")),
+                new(id: AedUnitCustomPrivilege.View,
+                    type: PrivilegeType.Entity,
+                    description: "View AED unit properties",
+                    details: "Allows the user to view the configuration of AED units.",
+                    priority: 2,
+                    icon: null,
+                    parentId: privilegeGroupId),
+                new(id: AedUnitCustomPrivilege.Modify,
+                    type: PrivilegeType.Entity,
+                    description: "Modify AED unit properties",
+                    details: "Allows the user to modify the configuration of AED units.",
+                    priority: 2,
+                    icon: null,
+                    parentId:  AedUnitCustomPrivilege.View),
+                new(id: AedUnitCustomPrivilege.Add,
+                    type: PrivilegeType.Entity,
+                    description: "Add AED units",
+                    details: "Allows the user to add AED units.",
+                    priority: 2,
+                    icon: null,
+                    parentId: AedUnitCustomPrivilege.Modify),
+                new(id: AedUnitCustomPrivilege.Delete,
+                    type: PrivilegeType.Entity,
+                    description: "Remove AED units",
+                    details: "Allows the user to remove AED units.",
+                    priority: 2,
+                    icon: null,
+                    parentId: AedUnitCustomPrivilege.Modify
+                )
+            });
         }
 
         public override void Unload()


### PR DESCRIPTION
Added Apache License 2.0 headers to all source files, replacing the previous proprietary license headers. Updated `AedUnitCustomEntityType` and `AedUnitCustomPrivilege` classes to use target-typed new expressions. Refactored `AedUnitInformation` class by moving `DataContractSerializer` initialization to a static readonly field, simplifying the `Serialize` method, and adding null or empty check in the `Deserialize` method. Refactored `CustomConfigPage` class by reordering private fields, adding comments, a public default constructor, validation in the `BeforeSave` method, and optional overrides for `Name` and `Image` properties. Refactored `SampleModule` class by adding `CreateCustomPrivileges` method, updating the `Load` method, and simplifying condition checks.