### PR TITLE
.NET 8 migration

### DIFF
--- a/Samples/Media SDK/BasicMediaPlayer/BasicMediaPlayer.csproj
+++ b/Samples/Media SDK/BasicMediaPlayer/BasicMediaPlayer.csproj
@@ -42,6 +42,13 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,17 +60,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Import Project="..\..\Shared\Shared.projitems" Label="Shared" />

--- a/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
+++ b/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,16 +59,7 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
+++ b/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,16 +59,7 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/OverlaySample/OverlaySample.csproj
+++ b/Samples/Media SDK/OverlaySample/OverlaySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,16 +59,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Include="PresentationCore" />
-	  <Reference Include="System" />
-	  <Reference Include="System.Core" />
-	  <Reference Include="System.Data.DataSetExtensions" />
-	  <Reference Include="System.Drawing" />
-	  <Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
+++ b/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,12 +55,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
+++ b/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,12 +55,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
+++ b/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,13 +56,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
+++ b/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,12 +55,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
+++ b/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,12 +55,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AccessControlRawEventQuerySample/AccessControlRawEventQuerySample.csproj
+++ b/Samples/Platform SDK/AccessControlRawEventQuerySample/AccessControlRawEventQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AccessControlReportQuerySample/AccessControlReportQuerySample.csproj
+++ b/Samples/Platform SDK/AccessControlReportQuerySample/AccessControlReportQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,10 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +49,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AccessControlUnitManagerSample/AccessControlUnitManagerSample.csproj
+++ b/Samples/Platform SDK/AccessControlUnitManagerSample/AccessControlUnitManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AccessControlUnitSample/AccessControlUnitSample.csproj
+++ b/Samples/Platform SDK/AccessControlUnitSample/AccessControlUnitSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,14 +47,10 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-	</ItemGroup>
-
+	
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Platform SDK/AccessEventMonitoringSample/AccessEventMonitoringSample.csproj
+++ b/Samples/Platform SDK/AccessEventMonitoringSample/AccessEventMonitoringSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.csproj
+++ b/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/ActivityTrailsSample/ActivityTrailsSample.csproj
+++ b/Samples/Platform SDK/ActivityTrailsSample/ActivityTrailsSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,14 +48,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-	</ItemGroup>
+
 
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>

--- a/Samples/Platform SDK/AlarmActivityQuerySample/AlarmActivityQuerySample.csproj
+++ b/Samples/Platform SDK/AlarmActivityQuerySample/AlarmActivityQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AlarmMonitoringSample/AlarmMonitoringSample.csproj
+++ b/Samples/Platform SDK/AlarmMonitoringSample/AlarmMonitoringSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/AuditTrailsSample/AuditTrailsSample.csproj
+++ b/Samples/Platform SDK/AuditTrailsSample/AuditTrailsSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -39,6 +39,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -46,13 +49,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CameraConfigurationSample/CameraConfigurationSample.csproj
+++ b/Samples/Platform SDK/CameraConfigurationSample/CameraConfigurationSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CameraSample/CameraSample.csproj
+++ b/Samples/Platform SDK/CameraSample/CameraSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Import Project="..\..\Shared\Shared.projitems" Label="Shared" />

--- a/Samples/Platform SDK/CopyConfiguratonSample/CopyConfiguratonSample.csproj
+++ b/Samples/Platform SDK/CopyConfiguratonSample/CopyConfiguratonSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CustomEntitySample/CustomEntitySample.csproj
+++ b/Samples/Platform SDK/CustomEntitySample/CustomEntitySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,17 +38,6 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<Reference Include="System" />
 		<Reference Include="System.Core" />
 		<Reference Include="PresentationCore" />
@@ -56,6 +45,15 @@
 		<Reference Include="System.Data.DataSetExtensions" />
 		<Reference Include="System.Data.Linq" />
 		<Reference Include="WindowsBase" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+		<Reference Include="Genetec.Sdk">
+			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CustomEventSample/CustomEventSample.csproj
+++ b/Samples/Platform SDK/CustomEventSample/CustomEventSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.Linq" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.Linq" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CustomFieldSample/CustomFieldSample.csproj
+++ b/Samples/Platform SDK/CustomFieldSample/CustomFieldSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,10 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Data.Linq" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,14 +49,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="System.Data.Linq" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/CustomIconSample/CustomIconSample.csproj
+++ b/Samples/Platform SDK/CustomIconSample/CustomIconSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>9</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>9</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,14 +47,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-	</ItemGroup>
-
+	
 	<ItemGroup>
 	  <Compile Update="Properties\Resources.Designer.cs">
 	    <DesignTime>True</DesignTime>

--- a/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
+++ b/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/DisplayInTileSample/DisplayInTileSample.csproj
+++ b/Samples/Platform SDK/DisplayInTileSample/DisplayInTileSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.csproj
+++ b/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/EntityCertificatesManagerSample/EntityCertificatesManagerSample.csproj
+++ b/Samples/Platform SDK/EntityCertificatesManagerSample/EntityCertificatesManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/EntityMappingSample/EntityMappingSample.csproj
+++ b/Samples/Platform SDK/EntityMappingSample/EntityMappingSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/EventMonitoringSample/EventMonitoringSample.csproj
+++ b/Samples/Platform SDK/EventMonitoringSample/EventMonitoringSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/EventToActionSample/EventToActionSample.csproj
+++ b/Samples/Platform SDK/EventToActionSample/EventToActionSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/IncidentManagerSample/IncidentManagerSample.csproj
+++ b/Samples/Platform SDK/IncidentManagerSample/IncidentManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,16 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/LicenseManagerSample/LicenseManagerSample.csproj
+++ b/Samples/Platform SDK/LicenseManagerSample/LicenseManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/LoggerSample/LoggerSample.csproj
+++ b/Samples/Platform SDK/LoggerSample/LoggerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,14 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+	  <None Update="LoggerSample.exe.gconfig">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
 	</ItemGroup>
 
 	<Import Project="..\..\Shared\Shared.projitems" Label="Shared" />

--- a/Samples/Platform SDK/LoginManagerSample/LoginManagerSample.csproj
+++ b/Samples/Platform SDK/LoginManagerSample/LoginManagerSample.csproj
@@ -10,14 +10,6 @@
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
-		<DefineConstants>NETFRAMEWORK_481</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<DefineConstants>NET8_0_WINDOWS</DefineConstants>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<DebugSymbols>true</DebugSymbols>
@@ -27,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -38,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -46,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/MacroSample/MacroSample.csproj
+++ b/Samples/Platform SDK/MacroSample/MacroSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -46,6 +46,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Scripting.Interfaces.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -61,13 +64,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Scripting.Interfaces.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/PeopleCountingSample/PeopleCountingSample.csproj
+++ b/Samples/Platform SDK/PeopleCountingSample/PeopleCountingSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/PlaySoundSample/PlaySoundSample.csproj
+++ b/Samples/Platform SDK/PlaySoundSample/PlaySoundSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/RaiseEventSample/RaiseEventSample.csproj
+++ b/Samples/Platform SDK/RaiseEventSample/RaiseEventSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/RequestManagerSample/RequestManagerSample.csproj
+++ b/Samples/Platform SDK/RequestManagerSample/RequestManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,14 +47,10 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-	</ItemGroup>
-
+	
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Platform SDK/SecurityManagerSample/SecurityManagerSample.csproj
+++ b/Samples/Platform SDK/SecurityManagerSample/SecurityManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/SequenceQuerySample/SequenceQuerySample.csproj
+++ b/Samples/Platform SDK/SequenceQuerySample/SequenceQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/ThumbnailQuerySample/ThumbnailQuerySample.csproj
+++ b/Samples/Platform SDK/ThumbnailQuerySample/ThumbnailQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/TimeAttendanceSample/TimeAttendanceSample.csproj
+++ b/Samples/Platform SDK/TimeAttendanceSample/TimeAttendanceSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/TransactionManagerSample/TransactionManagerSample.csproj
+++ b/Samples/Platform SDK/TransactionManagerSample/TransactionManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,16 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/TriggerAlarmSample/TriggerAlarmSample.csproj
+++ b/Samples/Platform SDK/TriggerAlarmSample/TriggerAlarmSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,16 +47,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/UnusedCredentialQuerySample/UnusedCredentialQuerySample.csproj
+++ b/Samples/Platform SDK/UnusedCredentialQuerySample/UnusedCredentialQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/UserTaskSample/UserTaskSample.csproj
+++ b/Samples/Platform SDK/UserTaskSample/UserTaskSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/VideoFileQuerySample/VideoFileQuerySample.csproj
+++ b/Samples/Platform SDK/VideoFileQuerySample/VideoFileQuerySample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.csproj
+++ b/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Platform SDK/VisitorManagerSample/VisitorManagerSample.csproj
+++ b/Samples/Platform SDK/VisitorManagerSample/VisitorManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,15 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net481|AnyCPU'">
-	  <DebugType>full</DebugType>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net481|AnyCPU'">
-	  <DebugType>full</DebugType>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -46,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Plugin SDK/BasicPluginTemplate/BasicPluginTemplate.csproj
+++ b/Samples/Plugin SDK/BasicPluginTemplate/BasicPluginTemplate.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Plugin.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,13 +56,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Plugin SDK/CustomActionSample/CustomActionSample.csproj
+++ b/Samples/Plugin SDK/CustomActionSample/CustomActionSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>9</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -51,6 +51,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -70,27 +75,12 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Remove="Resources\Images\SmallLogo.png" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Prism.Core" Version="8.1.97" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Resource Include="Resources\Images\SmallLogo.png" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Plugin SDK/CustomReportSample/CustomReportSample.csproj
+++ b/Samples/Plugin SDK/CustomReportSample/CustomReportSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -51,6 +51,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -70,19 +76,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Plugin SDK/PluginConfigurationSample/PluginConfigurationSample.csproj
+++ b/Samples/Plugin SDK/PluginConfigurationSample/PluginConfigurationSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>9</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -51,6 +51,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -70,21 +76,13 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Reactive" Version="6.0.1" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
+++ b/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
@@ -42,6 +42,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Plugin.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="PresentationCore" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,17 +56,12 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="PresentationCore" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/BackgroundProcessSample/BackgroundProcessSample.csproj
+++ b/Samples/Workspace SDK/BackgroundProcessSample/BackgroundProcessSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,15 +67,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>
 

--- a/Samples/Workspace SDK/BadgePrinterSample/BadgePrinterSample.csproj
+++ b/Samples/Workspace SDK/BadgePrinterSample/BadgePrinterSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,14 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="System.Printing" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="System.Drawing" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,18 +70,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="System.Printing" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="System.Drawing" />
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>
 

--- a/Samples/Workspace SDK/CardholderCredentialReaderSample/CardholderCredentialReaderSample.csproj
+++ b/Samples/Workspace SDK/CardholderCredentialReaderSample/CardholderCredentialReaderSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,16 +68,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Data.DataSetExtensions" />
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>
 

--- a/Samples/Workspace SDK/CardholderFieldsExtractorSample/CardholderFieldsExtractorSample.csproj
+++ b/Samples/Workspace SDK/CardholderFieldsExtractorSample/CardholderFieldsExtractorSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,15 +58,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/CommandManagerSample/CommandManagerSample.csproj
+++ b/Samples/Workspace SDK/CommandManagerSample/CommandManagerSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,15 +58,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Samples/Workspace SDK/ConfigPageSample/ConfigPageSample.csproj
+++ b/Samples/Workspace SDK/ConfigPageSample/ConfigPageSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,15 +67,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Workspace SDK/ControlsSample/ControlsSample.csproj
+++ b/Samples/Workspace SDK/ControlsSample/ControlsSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,19 +68,12 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Prism.Core" Version="8.1.97" />
-	</ItemGroup>
-	<ItemGroup>
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/CredentialBuilderSample/CredentialBuilderSample.csproj
+++ b/Samples/Workspace SDK/CredentialBuilderSample/CredentialBuilderSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,9 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,13 +48,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Data.DataSetExtensions" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/CredentialReaderSample/CredentialReaderSample.csproj
+++ b/Samples/Workspace SDK/CredentialReaderSample/CredentialReaderSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,16 +68,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Data.DataSetExtensions" />
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>
 

--- a/Samples/Workspace SDK/DashboardWidgetSample/DashboardWidgetSample.csproj
+++ b/Samples/Workspace SDK/DashboardWidgetSample/DashboardWidgetSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -43,6 +43,16 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Xaml" />
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Xml" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -54,20 +64,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="System.Xaml" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.Data" />
-		<Reference Include="System.Xml" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Workspace SDK/EventExtenderSample/EventExtenderSample.csproj
+++ b/Samples/Workspace SDK/EventExtenderSample/EventExtenderSample.csproj
@@ -42,6 +42,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,21 +58,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Compile Remove="Resources\**" />
-		<EmbeddedResource Remove="Resources\**" />
-		<None Remove="Resources\**" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Workspace SDK/ImageExtractorSample/ImageExtractorSample.csproj
+++ b/Samples/Workspace SDK/ImageExtractorSample/ImageExtractorSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,19 +58,12 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <Resource Include="Resources\Icon.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/OptionsExtensionSample/OptionsExtensionSample.csproj
+++ b/Samples/Workspace SDK/OptionsExtensionSample/OptionsExtensionSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,23 +67,12 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <Resource Include="Resources\Icon.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Samples/Workspace SDK/PageTaskSample/PageTaskSample.csproj
+++ b/Samples/Workspace SDK/PageTaskSample/PageTaskSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,15 +67,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/ReportExporterSample/ReportExporterSample.csproj
+++ b/Samples/Workspace SDK/ReportExporterSample/ReportExporterSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -38,6 +38,8 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -45,12 +47,11 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	

--- a/Samples/Workspace SDK/TaskSample/TaskSample.csproj
+++ b/Samples/Workspace SDK/TaskSample/TaskSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,22 +58,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Remove="Resources\Icon.bmp" />
-	  <None Remove="Resources\Icon.png" />
-	  <None Remove="Resources\Thumbnail.bmp" />
-	  <None Remove="Resources\Thumbnail.png" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Samples/Workspace SDK/TileViewSample/TileViewSample.csproj
+++ b/Samples/Workspace SDK/TileViewSample/TileViewSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,11 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,15 +67,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/TileWidgetSample/TileWidgetSample.csproj
+++ b/Samples/Workspace SDK/TileWidgetSample/TileWidgetSample.csproj
@@ -20,7 +20,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -31,7 +31,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -47,6 +47,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Drawing" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -62,16 +68,8 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Drawing" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">

--- a/Samples/Workspace SDK/TimelineProviderSample/TimelineProviderSample.csproj
+++ b/Samples/Workspace SDK/TimelineProviderSample/TimelineProviderSample.csproj
@@ -19,7 +19,7 @@
 		<DefineConstants>DEBUG;TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -30,7 +30,7 @@
 		<DefineConstants>TRACE</DefineConstants>
 		<ErrorReport>prompt</ErrorReport>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net481'">
@@ -42,6 +42,12 @@
 			<HintPath>$(GSC_SDK)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="PresentationCore" />
+		<Reference Include="PresentationFramework" />
+		<Reference Include="WindowsBase" />
+		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
@@ -53,18 +59,10 @@
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
+		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
 	</ItemGroup>
-	
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="PresentationFramework" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Data.DataSetExtensions" />
-	</ItemGroup>
-	
+		
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>


### PR DESCRIPTION
Updated C# language version and project references for improved compatibility and structure.
- Updated C# language version from 10 to 12 in all project files.
- Updated `Microsoft.Windows.Compatibility` package from version 8.0.6 to 8.0.8.
- Added `FrameworkReference` to `Microsoft.WindowsDesktop.App.WPF` for `net8.0-windows` target framework.
- Added essential .NET assembly references (`System`, `System.Core`, etc.) for `net481` target framework.
- Removed redundant `ItemGroup` sections and streamlined project references.
