### PR TITLE
MediaFile sample

### DIFF
--- a/Samples/Media SDK/MediaFileSample/Program.cs
+++ b/Samples/Media SDK/MediaFileSample/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright 2024 Genetec Inc.
+// Licensed under the Apache License, Version 2.0
+
+using System;
 using System.IO;
 using Genetec.Dap.CodeSamples;
 using Genetec.Sdk.Media;
@@ -7,71 +10,94 @@ SdkResolver.Initialize();
 
 RunSample();
 
+Console.Write("Press any key to exit...");
+Console.ReadKey(true);
+
 void RunSample()
 {
     string filePath = ReadFilePath();
     try
     {
+        // Create a MediaFile instance to inspect the file's metadata
+        // This will analyze the file structure without loading the actual media content
         MediaFile mediaFile = new(filePath);
-
         Console.WriteLine($"\nMedia file path: {mediaFile}");
 
+        // Display information about unique sources in the media file
+        // A unique source represents a distinct stream of data (video, audio, metadata)
         Console.WriteLine("\nUnique Sources:");
-        foreach (var source in mediaFile.UniqueSources)
+        foreach (UniqueSource source in mediaFile.UniqueSources)
         {
+            // Collection represents the device or system that generated the media
             Console.WriteLine($"Collection: {source.Collection} ({source.CollectionName})");
+
+            // Encoder identifies the specific camera or encoding device
             Console.WriteLine($"Encoder: {source.Encoder} ({source.EncoderName})");
+
+            // Origin provides information about where the stream came from
             Console.WriteLine($"Origin: {source.Origin}");
+
+            // MediaType indicates the type of data (video, audio, metadata, etc.)
             Console.WriteLine($"Media Type: {source.MediaType} ({GetMediaTypeName(source.MediaType)})");
+
+            // Usage indicates how the stream is intended to be used
             Console.WriteLine($"Usage: {source.Usage} ({GetUsageTypeName(source.Usage)})");
+
+            // Quick flags for identifying video and audio streams
             Console.WriteLine($"Is Video: {source.IsVideo}, Is Audio: {source.IsAudio}");
             Console.WriteLine();
         }
 
+        // Display information about individual files within the media container
+        // A single media file can contain multiple segments or streams
         Console.WriteLine("Contained Files:");
         foreach (var file in mediaFile.ContainedFiles)
         {
+            // Basic file information
             Console.WriteLine($"Filename: {file.Filename}");
+
+            // Timing information in the file's original timezone
             Console.WriteLine($"Start Time: {file.StartTime}");
             Console.WriteLine($"End Time: {file.EndTime}");
             Console.WriteLine($"Time Zone: {file.TimeZone}");
+
+            // Security features
             Console.WriteLine($"Is Watermarked: {file.IsWatermarked}");
+
+            // Link back to the source that generated this file
             Console.WriteLine($"Associated Unique Source: {file.UniqueSource}");
             Console.WriteLine();
         }
     }
-    catch (FormatException ex) // The file is not a valid media file
+    catch (FormatException ex) // Caught when the file format is not recognized
     {
         Console.WriteLine(ex.Message);
     }
-
-    Console.WriteLine("Press any key to exit...");
-    Console.ReadKey();
 }
 
+// Helper function to get a valid media file path from user input
 static string ReadFilePath()
 {
     while (true)
     {
         Console.Write("Please enter the path to a .g64, .g64x, or .mp4 file: ");
         string filePath = Console.ReadLine()?.Trim();
-
         if (string.IsNullOrEmpty(filePath))
         {
             Console.WriteLine("File path cannot be empty. Please try again.");
             continue;
         }
-
         if (!File.Exists(filePath))
         {
             Console.WriteLine($"The file {filePath} does not exist. Please try again.");
             continue;
         }
-
         return filePath;
     }
 }
 
+// Converts Security Center media type GUIDs to human-readable names
+// These types indicate what kind of data is stored in the stream
 static string GetMediaTypeName(Guid mediaType) => mediaType switch
 {
     _ when mediaType == StreamMediaType.Legacy => "Legacy",
@@ -87,6 +113,8 @@ static string GetMediaTypeName(Guid mediaType) => mediaType switch
     _ => "Unknown"
 };
 
+// Converts Security Center usage type GUIDs to human-readable names
+// These types indicate how the stream is intended to be used in the system
 static string GetUsageTypeName(Guid usageType) => usageType switch
 {
     _ when usageType == StreamUsageType.Live => "Live",

--- a/Samples/Media SDK/MediaFileSample/StreamMediaType.cs
+++ b/Samples/Media SDK/MediaFileSample/StreamMediaType.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright 2024 Genetec Inc.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+// Licensed under the Apache License, Version 2.0
 
 using System;
+
+namespace Genetec.Dap.CodeSamples;
 
 public static class StreamMediaType
 {

--- a/Samples/Media SDK/MediaFileSample/StreamUsageType.cs
+++ b/Samples/Media SDK/MediaFileSample/StreamUsageType.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright 2024 Genetec Inc.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+// Licensed under the Apache License, Version 2.0
 
 using System;
+
+namespace Genetec.Dap.CodeSamples;
 
 public static class StreamUsageType
 {


### PR DESCRIPTION
Added copyright and licensing information to `Program.cs`, `StreamMediaType.cs`, and `StreamUsageType.cs`. Included `using` directives for necessary namespaces in `Program.cs`. Initialized SDK with `SdkResolver.Initialize()` and added an exit prompt. Enhanced `RunSample` to provide detailed media file information and improved error handling. Added helper functions for media and usage type names. Removed redundant user prompts. Added namespace declarations and defined static readonly GUIDs for media and usage types.