### PR TITLE
PageTask sample

### DIFF
--- a/Samples/Workspace SDK/PageTaskSample/SamplePageDescriptor.cs
+++ b/Samples/Workspace SDK/PageTaskSample/SamplePageDescriptor.cs
@@ -35,7 +35,7 @@ public class SamplePageDescriptor : PageDescriptor
     public override bool HasPrivilege()
     {
         // TODO: Implement proper privilege checking logic
-        // Example: return CurrentUser.HasRequiredPermission("AccessSamplePage");
+        // Example: return m_sdk.LoggedUser?.HasPrivilege(SdkPrivilege.SystemTask) == true;
         return true;
     }
 }


### PR DESCRIPTION
Updated the `HasPrivilege` method in the `SamplePageDescriptor` class. The previous comment suggesting `CurrentUser.HasRequiredPermission("AccessSamplePage")` was replaced with a new comment recommending `m_sdk.LoggedUser?.HasPrivilege(SdkPrivilege.SystemTask) == true` for privilege checking. The method still returns `true`, but the new comment provides a more specific example for future implementation.