### PR TITLE
Fixed SdkResolver for .NET 8 

### DIFF
--- a/Samples/Media SDK/BasicMediaPlayer/BasicMediaPlayer.csproj
+++ b/Samples/Media SDK/BasicMediaPlayer/BasicMediaPlayer.csproj
@@ -54,11 +54,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
+++ b/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
@@ -53,11 +53,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 	</ItemGroup>

--- a/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
+++ b/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
@@ -53,11 +53,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 	</ItemGroup>

--- a/Samples/Media SDK/OverlaySample/OverlaySample.csproj
+++ b/Samples/Media SDK/OverlaySample/OverlaySample.csproj
@@ -53,11 +53,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
+++ b/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
@@ -49,11 +49,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
+++ b/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
@@ -49,11 +49,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
+++ b/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
@@ -50,11 +50,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/VideoConverterSample/VideoConverterSample.csproj
+++ b/Samples/Media SDK/VideoConverterSample/VideoConverterSample.csproj
@@ -49,11 +49,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
+++ b/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
@@ -49,11 +49,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
+++ b/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
@@ -49,11 +49,11 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Media">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessControlRawEventQuerySample/AccessControlRawEventQuerySample.csproj
+++ b/Samples/Platform SDK/AccessControlRawEventQuerySample/AccessControlRawEventQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessControlReportQuerySample/AccessControlReportQuerySample.csproj
+++ b/Samples/Platform SDK/AccessControlReportQuerySample/AccessControlReportQuerySample.csproj
@@ -47,7 +47,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessControlUnitManagerSample/AccessControlUnitManagerSample.csproj
+++ b/Samples/Platform SDK/AccessControlUnitManagerSample/AccessControlUnitManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessControlUnitSample/AccessControlUnitSample.csproj
+++ b/Samples/Platform SDK/AccessControlUnitSample/AccessControlUnitSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessEventMonitoringSample/AccessEventMonitoringSample.csproj
+++ b/Samples/Platform SDK/AccessEventMonitoringSample/AccessEventMonitoringSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.csproj
+++ b/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/ActivityTrailsSample/ActivityTrailsSample.csproj
+++ b/Samples/Platform SDK/ActivityTrailsSample/ActivityTrailsSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AlarmActivityQuerySample/AlarmActivityQuerySample.csproj
+++ b/Samples/Platform SDK/AlarmActivityQuerySample/AlarmActivityQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AlarmMonitoringSample/AlarmMonitoringSample.csproj
+++ b/Samples/Platform SDK/AlarmMonitoringSample/AlarmMonitoringSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/AuditTrailsSample/AuditTrailsSample.csproj
+++ b/Samples/Platform SDK/AuditTrailsSample/AuditTrailsSample.csproj
@@ -47,7 +47,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CameraConfigurationSample/CameraConfigurationSample.csproj
+++ b/Samples/Platform SDK/CameraConfigurationSample/CameraConfigurationSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CameraSample/CameraSample.csproj
+++ b/Samples/Platform SDK/CameraSample/CameraSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CopyConfiguratonSample/CopyConfiguratonSample.csproj
+++ b/Samples/Platform SDK/CopyConfiguratonSample/CopyConfiguratonSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CustomEntitySample/CustomEntitySample.csproj
+++ b/Samples/Platform SDK/CustomEntitySample/CustomEntitySample.csproj
@@ -51,7 +51,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CustomEventSample/CustomEventSample.csproj
+++ b/Samples/Platform SDK/CustomEventSample/CustomEventSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CustomFieldSample/CustomFieldSample.csproj
+++ b/Samples/Platform SDK/CustomFieldSample/CustomFieldSample.csproj
@@ -47,7 +47,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CustomIconSample/CustomIconSample.csproj
+++ b/Samples/Platform SDK/CustomIconSample/CustomIconSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/CustomReportQuerySample/CustomReportQuerySample.csproj
+++ b/Samples/Platform SDK/CustomReportQuerySample/CustomReportQuerySample.csproj
@@ -47,7 +47,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
+++ b/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/DisplayInTileSample/DisplayInTileSample.csproj
+++ b/Samples/Platform SDK/DisplayInTileSample/DisplayInTileSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/DoorSample/DoorSample.csproj
+++ b/Samples/Platform SDK/DoorSample/DoorSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.csproj
+++ b/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/EntityCertificatesManagerSample/EntityCertificatesManagerSample.csproj
+++ b/Samples/Platform SDK/EntityCertificatesManagerSample/EntityCertificatesManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/EntityMappingSample/EntityMappingSample.csproj
+++ b/Samples/Platform SDK/EntityMappingSample/EntityMappingSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/EventMonitoringSample/EventMonitoringSample.csproj
+++ b/Samples/Platform SDK/EventMonitoringSample/EventMonitoringSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/EventToActionSample/EventToActionSample.csproj
+++ b/Samples/Platform SDK/EventToActionSample/EventToActionSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/IncidentManagerSample/IncidentManagerSample.csproj
+++ b/Samples/Platform SDK/IncidentManagerSample/IncidentManagerSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/LicenseManagerSample/LicenseManagerSample.csproj
+++ b/Samples/Platform SDK/LicenseManagerSample/LicenseManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/LoggerSample/LoggerSample.csproj
+++ b/Samples/Platform SDK/LoggerSample/LoggerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/LoginManagerSample/LoginManagerSample.csproj
+++ b/Samples/Platform SDK/LoginManagerSample/LoginManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/MacroSample/MacroSample.csproj
+++ b/Samples/Platform SDK/MacroSample/MacroSample.csproj
@@ -54,15 +54,15 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Scripting.Compiler">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Scripting.Compiler.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Genetec.Sdk.Scripting.Interfaces">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Scripting.Interfaces.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/PeopleCountingSample/PeopleCountingSample.csproj
+++ b/Samples/Platform SDK/PeopleCountingSample/PeopleCountingSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/PlaySoundSample/PlaySoundSample.csproj
+++ b/Samples/Platform SDK/PlaySoundSample/PlaySoundSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/RaiseEventSample/RaiseEventSample.csproj
+++ b/Samples/Platform SDK/RaiseEventSample/RaiseEventSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/RequestManagerSample/RequestManagerSample.csproj
+++ b/Samples/Platform SDK/RequestManagerSample/RequestManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/SecurityManagerSample/SecurityManagerSample.csproj
+++ b/Samples/Platform SDK/SecurityManagerSample/SecurityManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/SequenceQuerySample/SequenceQuerySample.csproj
+++ b/Samples/Platform SDK/SequenceQuerySample/SequenceQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/ThumbnailQuerySample/ThumbnailQuerySample.csproj
+++ b/Samples/Platform SDK/ThumbnailQuerySample/ThumbnailQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/TimeAttendanceSample/TimeAttendanceSample.csproj
+++ b/Samples/Platform SDK/TimeAttendanceSample/TimeAttendanceSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/TransactionManagerSample/TransactionManagerSample.csproj
+++ b/Samples/Platform SDK/TransactionManagerSample/TransactionManagerSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/TriggerAlarmSample/TriggerAlarmSample.csproj
+++ b/Samples/Platform SDK/TriggerAlarmSample/TriggerAlarmSample.csproj
@@ -45,7 +45,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/UnusedCredentialQuerySample/UnusedCredentialQuerySample.csproj
+++ b/Samples/Platform SDK/UnusedCredentialQuerySample/UnusedCredentialQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/UserTaskSample/UserTaskSample.csproj
+++ b/Samples/Platform SDK/UserTaskSample/UserTaskSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/VideoFileQuerySample/VideoFileQuerySample.csproj
+++ b/Samples/Platform SDK/VideoFileQuerySample/VideoFileQuerySample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.csproj
+++ b/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Platform SDK/VisitorManagerSample/VisitorManagerSample.csproj
+++ b/Samples/Platform SDK/VisitorManagerSample/VisitorManagerSample.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
 		<Reference Include="Genetec.Sdk">
 			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
+			<Private>False</Private>
 		</Reference>
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
 		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />

--- a/Samples/Shared/SdkResolverNetCoreApp.cs
+++ b/Samples/Shared/SdkResolverNetCoreApp.cs
@@ -1,11 +1,4 @@
-﻿// Copyright 2024 Genetec Inc.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-#if NETCOREAPP
+﻿#if NETCOREAPP
 
 namespace Genetec.Dap.CodeSamples;
 
@@ -18,57 +11,43 @@ using System.Runtime.Loader;
 using Microsoft.Win32;
 using System.Collections.Concurrent;
 
-public class SdkResolver : AssemblyLoadContext
+public static class SdkResolver
 {
     private static readonly string s_probingPath = GetProbingPath();
-    private static readonly SdkResolver s_instance = new();
+    private static readonly AssemblyDependencyResolver s_dependencyResolver = new(Path.Combine(s_probingPath, "Genetec.Sdk.dll"));
     private static readonly ConcurrentDictionary<string, Assembly> s_loadedAssemblies = new();
     private static readonly HashSet<string> s_assemblyResolutionInProgress = new();
 
     public static void Initialize()
     {
-        Default.Resolving += OnAssemblyResolve;
-    }
-
-    protected override Assembly Load(AssemblyName assemblyName)
-    {
-        return ResolveAssembly(assemblyName);
+        AssemblyLoadContext.Default.Resolving += OnAssemblyResolve;
     }
 
     private static Assembly OnAssemblyResolve(AssemblyLoadContext context, AssemblyName assemblyName)
     {
-        return s_instance.ResolveAssembly(assemblyName);
-    }
-
-    private Assembly ResolveAssembly(AssemblyName assemblyName)
-    {
         if (s_loadedAssemblies.TryGetValue(assemblyName.Name, out Assembly loadedAssembly))
         {
-            return loadedAssembly;
+            return loadedAssembly; // Assembly already loaded
         }
 
         if (!s_assemblyResolutionInProgress.Add(assemblyName.Name))
         {
-            return null; // Prevent recursive resolution
+            return null; // Recursive resolution detected
         }
 
         try
         {
-            foreach (var assemblyFile in GetAssemblyPaths(s_probingPath, assemblyName).Where(File.Exists))
+            string assemblyPath = s_dependencyResolver.ResolveAssemblyToPath(assemblyName);
+            if (File.Exists(assemblyPath) && TryLoadAssembly(assemblyPath, out Assembly resolveAssembly))
             {
-                try
+                return resolveAssembly;
+            }
+
+            foreach (string assemblyFile in GetAssemblyPaths(s_probingPath, assemblyName).Where(File.Exists))
+            {
+                if (TryLoadAssembly(assemblyFile, out resolveAssembly))
                 {
-                    Assembly assembly = LoadFromAssemblyPath(assemblyFile);
-                    s_loadedAssemblies[assemblyName.Name] = assembly;
-                    return assembly;
-                }
-                catch (BadImageFormatException)
-                {
-                    // Skip assemblies that are not compatible
-                }
-                catch (Exception)
-                {
-                    // Log the exception if needed
+                    return resolveAssembly;
                 }
             }
         }
@@ -78,6 +57,28 @@ public class SdkResolver : AssemblyLoadContext
         }
 
         return null;
+
+        bool TryLoadAssembly(string assemblyPath, out Assembly resolveAssembly)
+        {
+            try
+            {
+                resolveAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+                s_loadedAssemblies[assemblyName.Name] = resolveAssembly;
+                return true;
+            }
+            catch (Exception)
+            {
+            }
+
+            resolveAssembly = default;
+            return false;
+        }
+
+        static IEnumerable<string> GetAssemblyPaths(string probingPath, AssemblyName assemblyName)
+        {
+            yield return Path.Combine(probingPath, $"{assemblyName.Name}.dll");
+            yield return Path.Combine(probingPath, $"{assemblyName.Name}.exe");
+        }
     }
 
     private static string GetProbingPath()
@@ -113,23 +114,17 @@ public class SdkResolver : AssemblyLoadContext
                         continue;
                     }
 
-                    if (subKey.GetValue("Installation Path") is string path) //SDK installation PATH
+                    if (subKey.GetValue("Installation Path") is string path)
                     {
                         yield return (version, path);
                     }
-                    else if (subKey.GetValue("InstallDir") is string dir) //Security Center installation PATH
+                    else if (subKey.GetValue("InstallDir") is string dir)
                     {
                         yield return (version, dir);
                     }
                 }
             }
         }
-    }
-
-    private static IEnumerable<string> GetAssemblyPaths(string probingPath, AssemblyName assemblyName)
-    {
-        yield return Path.Combine(probingPath, $"{assemblyName.Name}.dll");
-        yield return Path.Combine(probingPath, $"{assemblyName.Name}.exe");
     }
 }
 


### PR DESCRIPTION
Changed <Private> attribute to False for Genetec.Sdk references in multiple .csproj files.
Refactored SdkResolverNetCoreApp.cs to use AssemblyDependencyResolver, made SdkResolver a static class, and improved code readability.