### PR TITLE
VideoUnit sample

### DIFF
--- a/Samples/Platform SDK/VideoUnitSample/Program.cs
+++ b/Samples/Platform SDK/VideoUnitSample/Program.cs
@@ -43,7 +43,7 @@ async Task RunSample()
         {
             Console.WriteLine("Enrolling video unit from Generic RTSP stream...");
 
-            var uri = new Uri("rtsp://example.com:554/mystream/live"); // TODO: Replace with your RTSP stream URI
+            var uri = new Uri("rtsp://127.0.0.1:554/mystream/live"); // TODO: Replace with your RTSP stream URI
 
             // Create the AddVideoUnitInfo object without duplicating IP/port
             AddVideoUnitInfo addVideoUnitInfo = new(videoUnitProductInfo: productInfo,


### PR DESCRIPTION
The RTSP stream URI in the `RunSample` method of `Program.cs` was updated. The previous URI `rtsp://example.com:554/mystream/live` was replaced with `rtsp://127.0.0.1:554/mystream/live`.