### PR TITLE
Update README and SDK files for clarity and framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
 
    The SDK installer automatically:
    - Creates environment variables (`GSC_SDK` for .NET Framework, `GSC_SDK_CORE` for .NET 8)
-   - Write the installation path in Windows registry
+   - Writes the installation path in Windows registry
    - Copies the Security Center SDK assemblies in the SDK directories
    
    See [Referencing Security Center SDK Assemblies](https://github.com/Genetec/DAP/wiki/Referencing-Security-Center-SDK-Assemblies) for assembly referencing and runtime resolution details. 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
    The SDK installer automatically:
    - Creates environment variables (`GSC_SDK` for .NET Framework, `GSC_SDK_CORE` for .NET 8)
    - Writes the installation path in Windows registry
-   - Copies the Security Center SDK assemblies in the SDK directories
+   - Copies the Security Center SDK assemblies to the SDK directories
    
    See [Referencing Security Center SDK Assemblies](https://github.com/Genetec/DAP/wiki/Referencing-Security-Center-SDK-Assemblies) for assembly referencing and runtime resolution details. 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
 
   
 
--  **Install Security Center SDK**: The SDK contains the necessary libraries to build and run custom integrations. Download and install the Security Center SDK from the [Genetec Portal](https://portal.genetec.com). 
+-  **Install Security Center SDK**: The SDK contains the necessary libraries to build and run custom integrations. Download and install the Security Center SDK from the [Genetec Portal](https://portal.genetec.com).
+
+   The SDK installer automatically:
+   - Creates environment variables (`GSC_SDK` for .NET Framework, `GSC_SDK_CORE` for .NET 8)
+   - Write the installation path in Windows registry
+   - Copies the Security Center SDK assemblies in the SDK directories
+   
+   See [Referencing Security Center SDK Assemblies](https://github.com/Genetec/DAP/wiki/Referencing-Security-Center-SDK-Assemblies) for assembly referencing and runtime resolution details. 
 
 -  **Development Tools**:
 
@@ -42,13 +49,11 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
 
 -  **.NET Framework 4.8.1**: The sample projects can be built using .NET Framework 4.8.1, which is supported by all versions of Security Center.
 
--  **.NET 8**: Some sample projects can be built using .NET 8, but only with **Security Center SDK 5.12.2 or later**. Currently, only the platform SDK (Genetec.Sdk.dll) supports .NET 8. 
+-  **.NET 8**: Some sample projects can be built using .NET 8, but only with **Security Center SDK 5.12.2 or later**. Currently, only the **Platform SDK** (Genetec.Sdk.dll) supports .NET 8.
 
   
 
 -  **Build and Run the Samples**: Once your environment is ready, you can open the sample projects in Visual Studio, build them and run them.
-
-  
 
 ### 3. **Explore the Samples**:
 
@@ -73,17 +78,17 @@ The **core samples** that demonstrate fundamental Security Center SDK functional
 
 **Key capabilities demonstrated:**
 
-- Entity loading and caching patterns using the `SampleBase` class
+- Login and entity loading using the `SampleBase` class
 
-- Entity management
+- Entity creation, modification, and deletion
 
-- System reports and database queries
+- Reports queries
 
 - Event monitoring and alarm processing
 
-- Custom fields and entity creation
+- Custom fields 
 
-- Transaction management and authentication
+- Transaction management
 
   
 
@@ -115,6 +120,8 @@ Video and audio processing samples that **extend the Platform SDK** with special
 
 **Dependencies:** Built on Platform SDK foundations for entity management and SDK connection patterns.
 
+See the [Media SDK README](Samples/Media%20SDK/README.md).
+
   
 
 ### Workspace SDK Samples (`/Workspace SDK/`)
@@ -141,7 +148,7 @@ Client-side user interface extensions that **leverage Platform SDK entities and 
 
   
 
-For comprehensive implementation details, see the [Workspace SDK README](Workspace%20SDK/README.md).
+See the [Workspace SDK README](Samples/Workspace%20SDK/README.md).
 
   
 
@@ -168,7 +175,7 @@ Server-side plugin development samples that **build upon Platform SDK infrastruc
 
   
 
-For comprehensive implementation details, see the [Plugin SDK README](Plugin%20SDK/README.md).
+See the [Plugin SDK README](Samples/Plugin%20SDK/README.md).
 
   
 ## Sample Project Structure
@@ -282,6 +289,19 @@ dotnet build -f net8.0-windows
   
 
 Remember to use the appropriate version of the Security Center SDK that matches your target framework. The .NET 8 target requires Security Center SDK 5.12.2 or later.
+
+## SDK Framework Support Matrix
+
+The following table shows which .NET frameworks are supported by each SDK:
+
+| SDK | .NET Framework 4.8.1 | .NET 8 | Notes |
+|-----|:-------------------:|:------:|-------|
+| **Platform SDK** | ✅ | ✅ | .NET 8 requires Security Center SDK 5.12.2+ |
+| **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
+| **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
+| **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
+
+**Important**: Only Platform SDK samples support multi-targeting. All other SDK samples target .NET Framework 4.8.1 exclusively.
 
   
 

--- a/Samples/Directory.build.props
+++ b/Samples/Directory.build.props
@@ -4,6 +4,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+		<DefineConstants>$(DefineConstants);NET8_0</DefineConstants>
 	</PropertyGroup>
 </Project>

--- a/Samples/Media SDK/README.md
+++ b/Samples/Media SDK/README.md
@@ -2,6 +2,14 @@
 
 The Media SDK extends the Platform SDK with comprehensive video capabilities for Security Center. It provides real-time video streaming, playback control, audio transmission, PTZ camera operations, and video export functionality. This guide explains the core concepts, classes, and architectural patterns you need to understand when working with media in Security Center integrations.
 
+## Prerequisites
+
+- **.NET Framework 4.8.1**: The Media SDK only supports the .NET Framework; it does not support .NET 8 yet.  
+- **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
+- **Visual Studio 2022**: Version 17.6 or later for development
+- **Security Center**: Client applications (Security Desk and Config Tool) installed
+- **Valid Security Center License**: All samples include the development SDK certificate
+
 ## Media SDK Architecture
 
 ### Foundation on Platform SDK

--- a/Samples/Platform SDK/README.md
+++ b/Samples/Platform SDK/README.md
@@ -110,13 +110,17 @@ All samples follow consistent authentication patterns:
 - Display connection status and errors to the user
 - Handle authentication failures gracefully with clear error messages
 
-## Running the Samples
+## Prerequisites
 
-### Prerequisites
-Before running any Platform SDK sample, ensure you have:
-- Security Center installed and running on your system
-- SDK installed with proper environment variables configured
-- Valid Security Center user credentials with appropriate privileges
+- **.NET Framework 4.8.1 or .NET 8**: Platform SDK supports both frameworks (.NET 8 requires Security Center SDK 5.12.2+)
+- **Security Center SDK**: Installed with environment variables configured:
+  - `GSC_SDK`: Points to SDK location for .NET Framework
+  - `GSC_SDK_CORE`: Points to SDK location for .NET 8 (if using .NET 8)
+- **Visual Studio 2022**: Version 17.6 or later for development
+- **Security Center**: Installed and running on your system
+- **Valid Security Center License**: All samples include the development SDK certificate
+
+## Running the Samples
 
 ### Running a Sample
 1. **Update Connection Parameters**: Edit the hardcoded connection values in the sample to match your Security Center setup

--- a/Samples/Plugin SDK/README.md
+++ b/Samples/Plugin SDK/README.md
@@ -52,18 +52,12 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 
 ## Prerequisites
 
-- .NET Framework 4.8.1
-- Genetec Security Center SDK
-- Visual Studio 2022
+- **.NET Framework 4.8.1**: The Plugin SDK only supports the .NET Framework; it does not support .NET 8 yet.
+- **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
+- **Visual Studio 2022**: Version 17.6 or later for development (must run as Administrator)
+- **Security Center**: Installed and running on your system
+- **Valid Security Center License**: All samples include the development SDK certificate
 
-## Getting Started
-
-1. Install the latest Genetec Security Center SDK. This will create the necessary environment variables automatically.
-   - `GSC_SDK`: Points to the location of the Genetec SDK for .NET Framework 4.8.1
-   - `GSC_SDK_CORE`: Points to the location of the Genetec SDK for .NET 8
-2. Clone this repository to your local machine.
-3. Open the solution in Visual Studio **as an Administrator**.
-4. Build the project.
 
 ## Creating a Plugin
 

--- a/Samples/Shared/SdkResolverNetCoreApp.cs
+++ b/Samples/Shared/SdkResolverNetCoreApp.cs
@@ -1,7 +1,7 @@
 // Copyright 2025 Genetec Inc.
 // Licensed under the Apache License, Version 2.0
 
-#if NETCOREAPP
+#if NET8_0
 
 namespace Genetec.Dap.CodeSamples;
 

--- a/Samples/Workspace SDK/README.md
+++ b/Samples/Workspace SDK/README.md
@@ -3,6 +3,14 @@
 The Workspace SDK is a development framework that allows you to extend Security Center's client applications (Security Desk and Config Tool) with custom user interface components. It enables developers to create seamless integrations that feel like native parts of the Security Center experience.
 This guide demonstrates how to build a Workspace module for Security Center. Workspace modules allow you to extend Security Desk and Config Tool with custom UI tasks, panels, widgets, options, and other components.
 
+## Prerequisites
+
+- **.NET Framework 4.8.1**: The Workspace SDK only supports the .NET Framework; it does not support .NET 8 yet.  
+- **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
+- **Visual Studio 2022**: Version 17.6 or later for development
+- **Security Center**: Client applications (Security Desk and Config Tool) installed
+- **Valid Security Center License**: All samples include the development SDK certificate
+
 ## Overview
 
 Workspace modules run inside the Security Center client applications (Security Desk or Config Tool). They are loaded by these applications and provide custom user interface functionality. Unlike plugins, Workspace modules do not run as server-side Roles and are intended exclusively for client-side extensions.
@@ -64,13 +72,6 @@ All workspace modules loaded by Security Desk (or Config Tool) run within the sa
 - Implement proper exception handling to prevent crashes
 - Test modules together, not just individually
 - Consider the impact of your module on the overall Security Desk performance
-
-## Prerequisites
-
-* .NET Framework 4.8.1
-* Genetec Security Center SDK installed (creates required environment variables)
-  * `GSC_SDK`: Points to SDK location for .NET Framework
-* Visual Studio 2022
 
 ## Module Lifecycle and Resource Management
 


### PR DESCRIPTION
# Motivation
Enhance documentation clarity and provide updated information on SDK installation, prerequisites, and framework support.

# Modifications
* Updated README.md to clarify installation and prerequisites for the Security Center SDK, including environment variables created by the installer.
* Modified core samples section in README.md to emphasize login and entity loading while removing redundant phrases.
* Added "SDK Framework Support Matrix" section in README.md to outline supported .NET frameworks for each SDK.
* Changed define constant for .NET 8 in `Directory.build.props` from `NETCOREAPP` to `NET8_0` for better framework identification.
* Updated Media SDK Developer Guide in README.md to specify that it only supports .NET Framework 4.8.1.
* Expanded running samples section in README.md to include prerequisites for both .NET Framework 4.8.1 and .NET 8, with detailed instructions.
* Clarified prerequisites for using the Plugin SDK in README.md, noting it only supports .NET Framework 4.8.1.
* Updated preprocessor directive in `SdkResolverNetCoreApp.cs` to check for `NET8_0` instead of `NETCOREAPP`.
* Updated Workspace SDK section in README.md to include prerequisites similar to other SDKs, emphasizing .NET Framework 4.8.1 support only.
* Improved overall structure and clarity of README.md by removing redundant lines and highlighting important information.