### PR TITLE
Refactor namespaces and reorder using directives

### DIFF
--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionRecord.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionRecord.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright 2025 Genetec Inc.
 // Licensed under the Apache License, Version 2.0
 
-namespace Genetec.Dap.CodeSamples.Server.ReportHandlers;
+namespace Genetec.Dap.CodeSamples.Server.ReportHandlers.Intrusion;
 
 using System;
 

--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionReportHandler.cs
@@ -3,12 +3,12 @@
 
 namespace Genetec.Dap.CodeSamples.Server.ReportHandlers.Intrusion;
 
-using Genetec.Sdk;
-using Genetec.Sdk.Entities;
-using Genetec.Sdk.Queries.IntrusionDetection;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
+using Genetec.Sdk;
+using Genetec.Sdk.Entities;
+using Genetec.Sdk.Queries.IntrusionDetection;
 
 public class IntrusionDetectionReportHandler : ReportHandler<IntrusionDetectionReportQuery, IntrusionDetectionRecord>
 {

--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/Intrusion/IntrusionDetectionReportHandler.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright 2025 Genetec Inc.
 // Licensed under the Apache License, Version 2.0
 
-namespace Genetec.Dap.CodeSamples.Server.ReportHandlers;
+namespace Genetec.Dap.CodeSamples.Server.ReportHandlers.Intrusion;
 
-using System.Collections.Generic;
-using System.Data;
-using System.Threading.Tasks;
 using Genetec.Sdk;
 using Genetec.Sdk.Entities;
 using Genetec.Sdk.Queries.IntrusionDetection;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
 
 public class IntrusionDetectionReportHandler : ReportHandler<IntrusionDetectionReportQuery, IntrusionDetectionRecord>
 {

--- a/Samples/Plugin SDK/CustomReportSample/Server/SamplePlugin.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/SamplePlugin.cs
@@ -3,12 +3,8 @@
 
 namespace Genetec.Dap.CodeSamples.Server;
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using Genetec.Dap.CodeSamples.Server.ReportHandlers.Custom;
+using Genetec.Dap.CodeSamples.Server.ReportHandlers.Intrusion;
 using Genetec.Sdk;
 using Genetec.Sdk.Entities;
 using Genetec.Sdk.EventsArgs;
@@ -16,6 +12,11 @@ using Genetec.Sdk.Plugin;
 using ReportHandlers;
 using ReportHandlers.AccessControl;
 using ReportHandlers.Video;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 // Server-side plugin for the custom report sample.
 [PluginProperty(typeof(SamplePluginDescriptor))]
@@ -114,10 +115,10 @@ public class SamplePlugin : Plugin
             SendQueryCompleted(true);
             return;
         }
-      
+
         (Guid QueryId, int MessageId) key = (args.Query.QueryId, args.MessageId);
         using var tokenSource = new CancellationTokenSource();
-      
+
         if (m_queries.TryAdd(key, tokenSource))
         {
             try


### PR DESCRIPTION
Changed the namespace for `IntrusionDetectionRecord.cs` and `IntrusionDetectionReportHandler.cs` to `Genetec.Dap.CodeSamples.Server.ReportHandlers.Intrusion` for better modularization of intrusion-related components. Reordered `using` directives in `IntrusionDetectionReportHandler.cs` for consistency and adherence to coding style guidelines.