### PR TITLE
Refactor HandleAsync to return ReportError

### DIFF
--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/IReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/IReportHandler.cs
@@ -5,9 +5,10 @@ namespace Genetec.Dap.CodeSamples.Server.ReportHandlers;
 
 using System.Threading;
 using System.Threading.Tasks;
+using Genetec.Sdk;
 using Genetec.Sdk.EventsArgs;
 
 public interface IReportHandler
 {
-    Task HandleAsync(ReportQueryReceivedEventArgs args, CancellationToken token);
+    Task<ReportError> HandleAsync(ReportQueryReceivedEventArgs args, CancellationToken token);
 }

--- a/Samples/Plugin SDK/CustomReportSample/Server/SamplePlugin.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/SamplePlugin.cs
@@ -123,8 +123,16 @@ public class SamplePlugin : Plugin
         {
             try
             {
-                await handler.HandleAsync(args, tokenSource.Token);
-                SendQueryCompleted(true);
+                ReportError error = await handler.HandleAsync(args, tokenSource.Token);
+
+                if (error != ReportError.None)
+                {
+                    SendQueryCompleted(false, error, Severity.Warning, $"Query completed with error: {error}");
+                }
+                else
+                {
+                    SendQueryCompleted(true);
+                }
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
Changed the return type of `HandleAsync` in `IReportHandler` and `ReportHandler` to `Task<ReportError>` to provide error feedback. Updated `SamplePlugin` to handle the new return type, checking for errors and adjusting the completion status accordingly. Reorganized `using` directives in `ReportHandler.cs` for better code organization.