### PR TITLE
fix: resolve .NET 8 SDK transitive dependencies from deps.json files

### DIFF
--- a/Samples/Shared/SdkResolverNetCoreApp.cs
+++ b/Samples/Shared/SdkResolverNetCoreApp.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Text.Json;
 using Microsoft.Win32;
@@ -37,10 +36,12 @@ public static class SdkResolver
     private static Dictionary<string, string> BuildPackageAssemblyIndex(string probingPath)
     {
         var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var nugetCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
 
-        if (!Directory.Exists(nugetCache))
-            return index;
+        var nugetCache = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrWhiteSpace(nugetCache))
+            nugetCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+
+        bool hasNugetCache = Directory.Exists(nugetCache);
 
         foreach (var depsFile in Directory.EnumerateFiles(probingPath, "*.deps.json"))
         {
@@ -61,12 +62,17 @@ public static class SdkResolver
 
                         foreach (var runtimeEntry in runtime.EnumerateObject())
                         {
-                            var dllName = Path.GetFileNameWithoutExtension(runtimeEntry.Name);
+                            var runtimeName = runtimeEntry.Name;
+
+                            if (Path.IsPathRooted(runtimeName))
+                                continue;
+
+                            var dllName = Path.GetFileNameWithoutExtension(Path.GetFileName(runtimeName));
                             if (index.ContainsKey(dllName))
                                 continue;
 
                             // Check if DLL is already in the SDK folder
-                            var localPath = Path.Combine(probingPath, Path.GetFileName(runtimeEntry.Name));
+                            var localPath = Path.Combine(probingPath, Path.GetFileName(runtimeName));
                             if (File.Exists(localPath))
                             {
                                 index[dllName] = localPath;
@@ -74,24 +80,29 @@ public static class SdkResolver
                             }
 
                             // Try to find in NuGet cache
-                            var packageParts = package.Name.Split('/');
-                            if (packageParts.Length == 2)
+                            if (hasNugetCache)
                             {
-                                var packagePath = Path.Combine(nugetCache, packageParts[0].ToLowerInvariant(), packageParts[1], runtimeEntry.Name);
-                                if (File.Exists(packagePath))
+                                var packageParts = package.Name.Split('/');
+                                if (packageParts.Length == 2)
                                 {
-                                    index[dllName] = packagePath;
+                                    var packagePath = Path.Combine(nugetCache, packageParts[0].ToLowerInvariant(), packageParts[1], runtimeName);
+                                    if (File.Exists(packagePath))
+                                    {
+                                        index[dllName] = packagePath;
+                                    }
                                 }
                             }
                         }
                     }
-
-                    break; // Only process the first target
                 }
             }
-            catch
+            catch (JsonException)
             {
                 // Skip malformed deps.json files
+            }
+            catch (IOException)
+            {
+                // Skip files that cannot be read
             }
         }
 
@@ -119,6 +130,9 @@ public static class SdkResolver
 
     private static Assembly LoadAssembly(AssemblyLoadContext context, AssemblyName assemblyName)
     {
+        if (s_packageAssemblyPaths == null)
+            return null;
+
         // 1) Try the package assembly index (built from all .deps.json files)
         if (s_packageAssemblyPaths.TryGetValue(assemblyName.Name, out var resolvedPath) && File.Exists(resolvedPath))
         {
@@ -126,7 +140,7 @@ public static class SdkResolver
             {
                 return context.LoadFromAssemblyPath(resolvedPath);
             }
-            catch (Exception)
+            catch (BadImageFormatException)
             {
                 // Fall through to next resolution strategy
             }
@@ -141,7 +155,7 @@ public static class SdkResolver
                 {
                     return context.LoadFromAssemblyPath(candidate);
                 }
-                catch (Exception)
+                catch (BadImageFormatException)
                 {
                     // Ignore and try next candidate
                 }

--- a/Samples/Shared/SdkResolverNetCoreApp.cs
+++ b/Samples/Shared/SdkResolverNetCoreApp.cs
@@ -10,14 +10,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Text.Json;
 using Microsoft.Win32;
 using System.Collections.Concurrent;
 
 public static class SdkResolver
 {
     private static string s_probingPath;
-    private static AssemblyDependencyResolver s_dependencyResolver;
+    private static Dictionary<string, string> s_packageAssemblyPaths;
     private static readonly ConcurrentDictionary<string, Lazy<Assembly>> s_loaders = new(StringComparer.OrdinalIgnoreCase);
 
     public static void Initialize()
@@ -27,10 +29,73 @@ public static class SdkResolver
         if (string.IsNullOrEmpty(s_probingPath))
             throw new InvalidOperationException("SDK probing path could not be found.");
 
-        var sdkDll = Path.Combine(s_probingPath, "Genetec.Sdk.dll");
-        s_dependencyResolver = File.Exists(sdkDll) ? new AssemblyDependencyResolver(sdkDll) : null;
+        s_packageAssemblyPaths = BuildPackageAssemblyIndex(s_probingPath);
 
         AssemblyLoadContext.Default.Resolving += OnAssemblyResolve;
+    }
+
+    private static Dictionary<string, string> BuildPackageAssemblyIndex(string probingPath)
+    {
+        var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var nugetCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
+
+        if (!Directory.Exists(nugetCache))
+            return index;
+
+        foreach (var depsFile in Directory.EnumerateFiles(probingPath, "*.deps.json"))
+        {
+            try
+            {
+                using var stream = File.OpenRead(depsFile);
+                using var doc = JsonDocument.Parse(stream);
+
+                if (!doc.RootElement.TryGetProperty("targets", out var targets))
+                    continue;
+
+                foreach (var target in targets.EnumerateObject())
+                {
+                    foreach (var package in target.Value.EnumerateObject())
+                    {
+                        if (!package.Value.TryGetProperty("runtime", out var runtime))
+                            continue;
+
+                        foreach (var runtimeEntry in runtime.EnumerateObject())
+                        {
+                            var dllName = Path.GetFileNameWithoutExtension(runtimeEntry.Name);
+                            if (index.ContainsKey(dllName))
+                                continue;
+
+                            // Check if DLL is already in the SDK folder
+                            var localPath = Path.Combine(probingPath, Path.GetFileName(runtimeEntry.Name));
+                            if (File.Exists(localPath))
+                            {
+                                index[dllName] = localPath;
+                                continue;
+                            }
+
+                            // Try to find in NuGet cache
+                            var packageParts = package.Name.Split('/');
+                            if (packageParts.Length == 2)
+                            {
+                                var packagePath = Path.Combine(nugetCache, packageParts[0].ToLowerInvariant(), packageParts[1], runtimeEntry.Name);
+                                if (File.Exists(packagePath))
+                                {
+                                    index[dllName] = packagePath;
+                                }
+                            }
+                        }
+                    }
+
+                    break; // Only process the first target
+                }
+            }
+            catch
+            {
+                // Skip malformed deps.json files
+            }
+        }
+
+        return index;
     }
 
     private static Assembly OnAssemblyResolve(AssemblyLoadContext context, AssemblyName assemblyName)
@@ -54,10 +119,18 @@ public static class SdkResolver
 
     private static Assembly LoadAssembly(AssemblyLoadContext context, AssemblyName assemblyName)
     {
-        // 1) Try AssemblyDependencyResolver
-        var path = s_dependencyResolver.ResolveAssemblyToPath(assemblyName);
-        if (!string.IsNullOrEmpty(path) && File.Exists(path))
-            return context.LoadFromAssemblyPath(path);
+        // 1) Try the package assembly index (built from all .deps.json files)
+        if (s_packageAssemblyPaths.TryGetValue(assemblyName.Name, out var resolvedPath) && File.Exists(resolvedPath))
+        {
+            try
+            {
+                return context.LoadFromAssemblyPath(resolvedPath);
+            }
+            catch (Exception)
+            {
+                // Fall through to next resolution strategy
+            }
+        }
 
         // 2) Try direct probing folder
         if (!string.IsNullOrEmpty(s_probingPath))


### PR DESCRIPTION
The SdkResolver previously only used Genetec.Sdk.deps.json to resolve dependencies. Assemblies required by transitive dependencies (e.g., Genetec.Platform.Security) that were not listed in Genetec.Sdk.deps.json and not physically present in the SDK installation folder could not be found, causing authentication failures (ConnectionEstablished → Failed).

The resolver now parses all .deps.json files in the SDK folder and builds an index that maps assembly names to file paths, checking the SDK folder first and falling back to the local NuGet package cache.