### PR TITLE
docs: fix typos in sample READMEs

### DIFF
--- a/Samples/Platform SDK/README.md
+++ b/Samples/Platform SDK/README.md
@@ -275,5 +275,5 @@ These samples demonstrate specialized SDK capabilities:
 The classes and concepts demonstrated in these Platform SDK samples form the foundation for all other Security Center SDK development:
 
 - **Media SDK**: These samples build on Platform SDK entity management (cameras, video units) and add media-specific operations like streaming and playback
-- **Workspace SDK**: These samples the Platform SDK within Security Desk and Config Tool client applications  
+- **Workspace SDK**: These samples use the Platform SDK within Security Desk and Config Tool client applications  
 - **Plugin SDK**: These samples extend Platform SDK for server-side role development

--- a/Samples/Plugin SDK/README.md
+++ b/Samples/Plugin SDK/README.md
@@ -513,7 +513,7 @@ By properly implementing the `GetSpecificCreationScript` method, you ensure that
 
 #### Overview
 
-`DatabaseUpgradeItem` is a important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
+`DatabaseUpgradeItem` is an important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
 
 #### Purpose
 
@@ -664,7 +664,7 @@ public override void DatabaseCleanup(string name, int retentionPeriod)
 
 #### Integration with Security Center
 
-By implementing `DatabaseCleanupThreshold` allows the plugin to:
+Implementing `DatabaseCleanupThreshold` allows the plugin to:
 
 - View and modify retention periods for different types of data
 - Schedule cleanup operations according to the plugin configuration


### PR DESCRIPTION
## Summary
- Fix dropped verb in Platform SDK README ("These samples the Platform SDK" -> "These samples use the Platform SDK")
- Fix "a important" -> "an important" in Plugin SDK README
- Fix dangling-modifier sentence "By implementing X allows..." -> "Implementing X allows..." in Plugin SDK README