### PR TITLE
fix: align sample AssemblyName with folder/project name

### DIFF
--- a/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
+++ b/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net481</TargetFrameworks>
 		<RootNamespace>Genetec.Dap.CodeSamples</RootNamespace>
-		<AssemblyName>FileCryptingManager</AssemblyName>
+		<AssemblyName>FileCryptingManagerSample</AssemblyName>
 		<Description>Sample project</Description>
 		<Company>Genetec Inc.</Company>
 		<Copyright>Copyright © Genetec Inc. 2024</Copyright>

--- a/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
+++ b/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
@@ -11,7 +11,7 @@
 		<TargetFrameworks Condition="$(Configuration.EndsWith('_NET481'))">net481</TargetFrameworks>
 		<Configurations>Debug;Release;Debug_NET481;Debug_NET8;Release_NET481;Release_NET8</Configurations>
 		<RootNamespace>Genetec.Dap.CodeSamples</RootNamespace>
-		<AssemblyName>DiagnosticServer</AssemblyName>
+		<AssemblyName>DiagnosticServerSample</AssemblyName>
 		<Description>Sample project</Description>
 		<Company>Genetec Inc.</Company>
 		<Copyright>Copyright © Genetec Inc. 2024</Copyright>

--- a/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
+++ b/Samples/Platform SDK/DiagnosticServerSample/DiagnosticServerSample.csproj
@@ -14,7 +14,7 @@
 		<AssemblyName>DiagnosticServerSample</AssemblyName>
 		<Description>Sample project</Description>
 		<Company>Genetec Inc.</Company>
-		<Copyright>Copyright © Genetec Inc. 2024</Copyright>
+		<Copyright>Copyright Â© Genetec Inc. 2024</Copyright>
 		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Summary
- `DiagnosticServerSample` produced `DiagnosticServer.exe` (folder: `DiagnosticServerSample`)
- `FileCryptingManagerSample` produced `FileCryptingManager.exe` (folder: `FileCryptingManagerSample`)

Every other sample uses the `...Sample` suffix matching its folder. Aligning these two restores the convention.