### PR TITLE
docs: add Genetec Web Player section to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Hosting samples for the **Genetec Web Player** (GWP), the JavaScript video playe
 
 **Hosting models demonstrated:**
 
-- **GwpDesktopPlayerSample**: A WPF desktop application that hosts GWP in an embedded `WebView2` control, with token retrieval performed natively in .NET.
-- **GwpMinimalApiSample**: An ASP.NET Core Minimal API application that serves a static page and proxies token requests through a server-side endpoint.
-- **GwpRazorPagesSample**: An ASP.NET Core Razor Pages application that adds production-ready CSP nonce support and server-rendered configuration on top of the Minimal API pattern.
+- WPF desktop application that hosts GWP in an embedded `WebView2` control, with token retrieval performed natively in .NET
+- ASP.NET Core Minimal API application that serves a static page and proxies token requests through a server-side endpoint
+- ASP.NET Core Razor Pages application that adds production-ready CSP nonce support and server-rendered configuration on top of the Minimal API pattern
 
   
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
 
 -  **.NET Framework 4.8.1**: The sample projects can be built using .NET Framework 4.8.1, which is supported by all versions of Security Center.
 
--  **.NET 8**: Some sample projects can be built using .NET 8, but only with **Security Center SDK 5.12.2 or later**. Currently, only the **Platform SDK** (Genetec.Sdk.dll) supports .NET 8.
+-  **.NET 8**: Some sample projects can be built using .NET 8. Platform SDK samples require **Security Center SDK 5.12.2 or later**; Plugin SDK .NET 8 support applies to server modules in **Security Center 5.13 or later**; Genetec Web Player samples target .NET 8 and do not use the .NET Security Center SDK.
 
   
 
@@ -312,17 +312,17 @@ Remember to use the appropriate version of the Security Center SDK that matches 
 
 ## SDK Framework Support Matrix
 
-The following table shows which .NET frameworks are supported by each SDK:
+The following table shows which .NET frameworks are supported by each SDK or sample group:
 
 | SDK | .NET Framework 4.8.1 | .NET 8 | Notes |
 |-----|:-------------------:|:------:|-------|
+| **Genetec Web Player** | ❌ | ✅ | Targets .NET 8 only; ASP.NET Core or WPF + WebView2 |
 | **Platform SDK** | ✅ | ✅ | .NET 8 requires Security Center SDK 5.12.2+ |
 | **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
 | **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
-| **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
-| **Genetec Web Player** | ❌ | ✅ | Targets .NET 8 only; ASP.NET Core or WPF + WebView2 |
+| **Plugin SDK** | ✅ | ✅ | .NET 8 support for the `ServerModule` requires Security Center 5.13+. The `ClientModule` (Config Tool / Security Desk UI) targets .NET Framework only. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8). |
 
-**Important**: Only Platform SDK samples support multi-targeting. Platform SDK samples may target either .NET Framework 4.8.1 or .NET 8. Media SDK, Workspace SDK, and Plugin SDK samples target .NET Framework 4.8.1 exclusively, while Genetec Web Player samples target .NET 8 exclusively.
+**Important**: Only Platform SDK samples in this repository are configured to multi-target. The Plugin, Workspace, and Media SDK samples target .NET Framework 4.8.1 exclusively, even where the SDK itself supports additional runtimes (see Plugin SDK row above).
 
   
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The following table shows which .NET frameworks are supported by each SDK:
 | **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
 | **Genetec Web Player** | ❌ | ✅ | Targets .NET 8 only; ASP.NET Core or WPF + WebView2 |
 
-**Important**: Only Platform SDK samples support multi-targeting. The other Security Center SDK samples target .NET Framework 4.8.1 exclusively, and the Genetec Web Player samples target .NET 8 exclusively.
+**Important**: Only Platform SDK samples support multi-targeting. Platform SDK samples may target either .NET Framework 4.8.1 or .NET 8. Media SDK, Workspace SDK, and Plugin SDK samples target .NET Framework 4.8.1 exclusively, while Genetec Web Player samples target .NET 8 exclusively.
 
   
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ After setting up your environment, you can explore the sample projects in this r
 ## Security Center SDKs
 
   
-The sample projects in this repository are organized into four main SDKs, each building upon the foundational Platform SDK:
+The sample projects in this repository are organized into four Security Center SDKs (each building upon the foundational Platform SDK) and a separate collection of Genetec Web Player samples:
 
   
 
@@ -176,6 +176,33 @@ Server-side plugin development samples that **build upon Platform SDK infrastruc
   
 
 See the [Plugin SDK README](Samples/Plugin%20SDK/README.md).
+
+  
+
+### Genetec Web Player Samples (`/Genetec Web Player/`)
+
+  
+
+Hosting samples for the **Genetec Web Player** (GWP), the JavaScript video player that ships with the Media Gateway. Unlike the SDK samples, these projects do not connect through the .NET Security Center SDK; they demonstrate three different application shells that load `gwp.js` from a Media Gateway and supply it with opaque camera tokens.
+
+  
+
+**Hosting models demonstrated:**
+
+- **GwpDesktopPlayerSample**: A WPF desktop application that hosts GWP in an embedded `WebView2` control, with token retrieval performed natively in .NET.
+- **GwpMinimalApiSample**: An ASP.NET Core Minimal API application that serves a static page and proxies token requests through a server-side endpoint.
+- **GwpRazorPagesSample**: An ASP.NET Core Razor Pages application that adds production-ready CSP nonce support and server-rendered configuration on top of the Minimal API pattern.
+
+  
+
+**Prerequisites differ from the SDK samples**: GWP samples require a reachable Media Gateway, a trusted (or development) Media Gateway certificate, and CORS configuration that allows the hosting page's origin. See each sample's README for details.
+
+  
+
+See the per-sample READMEs:
+- [GwpDesktopPlayerSample](Samples/Genetec%20Web%20Player/GwpDesktopPlayerSample/README.md)
+- [GwpMinimalApiSample](Samples/Genetec%20Web%20Player/GwpMinimalApiSample/README.md)
+- [GwpRazorPagesSample](Samples/Genetec%20Web%20Player/GwpRazorPagesSample/README.md)
 
   
 ## Sample Project Structure
@@ -300,8 +327,9 @@ The following table shows which .NET frameworks are supported by each SDK:
 | **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
 | **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
 | **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
+| **Genetec Web Player** | ❌ | ✅ | Targets .NET 8 only; ASP.NET Core or WPF + WebView2 |
 
-**Important**: Only Platform SDK samples support multi-targeting. All other SDK samples target .NET Framework 4.8.1 exclusively.
+**Important**: Only Platform SDK samples support multi-targeting. The other Security Center SDK samples target .NET Framework 4.8.1 exclusively, and the Genetec Web Player samples target .NET 8 exclusively.
 
   
 

--- a/README.md
+++ b/README.md
@@ -198,13 +198,6 @@ Hosting samples for the **Genetec Web Player** (GWP), the JavaScript video playe
 **Prerequisites differ from the SDK samples**: GWP samples require a reachable Media Gateway, a trusted (or development) Media Gateway certificate, and CORS configuration that allows the hosting page's origin. See each sample's README for details.
 
   
-
-See the per-sample READMEs:
-- [GwpDesktopPlayerSample](Samples/Genetec%20Web%20Player/GwpDesktopPlayerSample/README.md)
-- [GwpMinimalApiSample](Samples/Genetec%20Web%20Player/GwpMinimalApiSample/README.md)
-- [GwpRazorPagesSample](Samples/Genetec%20Web%20Player/GwpRazorPagesSample/README.md)
-
-  
 ## Sample Project Structure
 
   


### PR DESCRIPTION
This pull request updates the root README.md to add documentation for the Genetec Web Player samples and clarify the framework support matrix.

Changes:

- Adds a Genetec Web Player section covering the sample purpose, hosting models, and prerequisites.
- Adds Genetec Web Player to the framework support matrix as a .NET 8-only sample group.
- Aligns the Plugin SDK framework support text with the current .NET 8 reality: ServerModule supports .NET 8 with Security Center 5.13+, while ClientModule remains .NET Framework-only.
- Clarifies the difference between SDK runtime support and the sample project configurations in this repository.