### PR TITLE
fix: bump Microsoft.Data.SqlClient to 6.0.5 in PluginDatabaseSample

### DIFF
--- a/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
+++ b/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
@@ -61,7 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+	  <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.5" />
 	</ItemGroup>
 
 	<Target Name="CopyCertificates" AfterTargets="Build">


### PR DESCRIPTION
This pull request updates the `Microsoft.Data.SqlClient` package in the `PluginDatabaseSample` project to a newer version.

Dependency update:

* Upgraded the `Microsoft.Data.SqlClient` NuGet package from version 5.2.2 to 6.0.5 in `PluginDatabaseSample.csproj` to ensure compatibility with the latest features and security fixes.