### PR TITLE
fix: replace deprecated API usage in Platform SDK samples

### DIFF
--- a/Samples/Platform SDK/ArchiverRoleSample/ArchiverRoleSample.cs
+++ b/Samples/Platform SDK/ArchiverRoleSample/ArchiverRoleSample.cs
@@ -194,7 +194,7 @@ public class ArchiverRoleSample : SampleBase
                                    Valid From: {cert.NotBefore}
                                    Valid Until: {cert.NotAfter}
                                    Has Private Key: {cert.HasPrivateKey}
-                                   Public Key Algorithm: {cert.PublicKey.Key.KeyExchangeAlgorithm}
+                                   Public Key Algorithm: {cert.PublicKey.Oid.FriendlyName}
                                    Signature Algorithm: {cert.SignatureAlgorithm.FriendlyName}
                                    Version: {cert.Version}
                                    Friendly Name: {cert.FriendlyName}

--- a/Samples/Platform SDK/CredentialBuilderSample/CredentialBuilderSample.cs
+++ b/Samples/Platform SDK/CredentialBuilderSample/CredentialBuilderSample.cs
@@ -32,7 +32,7 @@ public class CredentialBuilderSample : SampleBase
         await BuildAndDisplayCredential(engine, credentialBuilder, "48-Bit Corporate 1000 Wiegand Credential", new Wiegand48BitCorporate1000CredentialFormat(companyId: 1, cardId: 2));
         await BuildAndDisplayCredential(engine, credentialBuilder, "Corporate 1000 Wiegand Credential", new WiegandCorporate1000CredentialFormat(companyId: 1, cardId: 2));
         await BuildAndDisplayCredential(engine, credentialBuilder, "License Plate Credential", new LicensePlateCredentialFormat(licensePlate: "12345"));
-        await BuildAndDisplayCredential(engine, credentialBuilder, "Keypad Credential", new KeypadCredentialFormat(credentialCode: 12345));
+        await BuildAndDisplayCredential(engine, credentialBuilder, "Keypad Credential", new KeypadCredentialFormat(credentialCode: "12345"));
         await BuildAndDisplayCredential(engine, credentialBuilder, "Raw Card Credential", new RawCardCredentialFormat(rawData: "1234", bitLength: 32));
 
         var fascN75Dict = new Dictionary<string, string>

--- a/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.cs
+++ b/Samples/Platform SDK/EntityCacheSample/EntityCacheSample.cs
@@ -78,7 +78,9 @@ public class EntityCacheSample : SampleBase
 
         int totalEntities = 0;
 
+#pragma warning disable CS0612 // EntityType.ReportTemplate is obsolete; we filter it explicitly so it is not iterated
         foreach (var entityType in Enum.GetValues(typeof(EntityType)).OfType<EntityType>().Except(new[] { EntityType.None, EntityType.ReportTemplate }).OrderBy(type => type.ToString()))
+#pragma warning restore CS0612
         {
             int count = engine.GetEntities(entityType).Count;
             totalEntities += count;

--- a/Samples/Platform SDK/RoleSample/RoleSample.cs
+++ b/Samples/Platform SDK/RoleSample/RoleSample.cs
@@ -300,7 +300,7 @@ public class RoleSample : SampleBase
             Console.WriteLine($"    Valid From: {cert.NotBefore:f}");
             Console.WriteLine($"    Valid Until: {cert.NotAfter:f}");
             Console.WriteLine($"    Has Private Key: {cert.HasPrivateKey}");
-            Console.WriteLine($"    Public Key Algorithm: {cert.PublicKey.Key.KeyExchangeAlgorithm}");
+            Console.WriteLine($"    Public Key Algorithm: {cert.PublicKey.Oid.FriendlyName}");
             Console.WriteLine($"    Signature Algorithm: {cert.SignatureAlgorithm.FriendlyName}");
             Console.WriteLine($"    Version: {cert.Version}");
             Console.WriteLine($"    Friendly Name: {cert.FriendlyName}");


### PR DESCRIPTION
Resolves four obsolete-API warnings surfaced by a clean rebuild:

- CredentialBuilderSample: KeypadCredentialFormat(short) -> KeypadCredentialFormat(string). The short overload is obsolete because it does not preserve leading zeros in credential codes.
- EntityCacheSample: suppress CS0612 around the EntityType enumeration. The sample explicitly excludes EntityType.ReportTemplate (now obsolete) from the iterated set, so the reference is intentional. Pragma documents intent and silences the warning.
- ArchiverRoleSample / RoleSample: cert.PublicKey.Key.KeyExchangeAlgorithm -> cert.PublicKey.Oid.FriendlyName. The .Key property is obsolete on .NET 8; Oid.FriendlyName returns the algorithm name (RSA, ECC, DSA) without the deprecated AsymmetricAlgorithm round-trip, and works on both target frameworks.

Verified locally (rebased onto fix/restore-vcard-per-project for build): all four projects compile with zero deprecated-API warnings remaining.

Note: this branch is based on main, which currently has the broken VCard build (resolved by PR #179). Reviewers will see CI failures from the VCard issue until #179 lands; the diff in this PR is independent and clean.