### PR TITLE
docs: align Plugin SDK READMEs with .NET 8 support reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ The following table shows which .NET frameworks are supported by each SDK:
 | **Platform SDK** | ✅ | ✅ | .NET 8 requires Security Center SDK 5.12.2+ |
 | **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
 | **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
-| **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
+| **Plugin SDK** | ✅ | ✅ | .NET 8 support for the `ServerModule` requires Security Center 5.13+. The `ClientModule` (Config Tool / Security Desk UI) targets .NET Framework only. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8). |
 
-**Important**: Only Platform SDK samples support multi-targeting. All other SDK samples target .NET Framework 4.8.1 exclusively.
+**Important**: Only Platform SDK samples in this repository are configured to multi-target. The Plugin, Workspace, and Media SDK samples target .NET Framework 4.8.1 exclusively, even where the SDK itself supports additional runtimes (see Plugin SDK row above).
 
   
 

--- a/Samples/Plugin SDK/README.md
+++ b/Samples/Plugin SDK/README.md
@@ -52,8 +52,8 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 
 ## Prerequisites
 
-- **.NET Framework 4.8.1**: The Plugin SDK only supports the .NET Framework; it does not support .NET 8 yet.
-- **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
+- **.NET Framework 4.8.1 or .NET 8**: The Plugin SDK supports both runtimes. A plugin's `ServerModule` (the role logic) can target .NET Framework 4.8.1 (any Security Center version), .NET 8 (Security Center 5.13 or later), or .NET 10 (Security Center 5.14.1 or later). The `ClientModule`, when present, must target .NET Framework 4.8.1 because Config Tool and Security Desk run on .NET Framework. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8) for project-structure options.
+- **Security Center SDK**: Installed with the `GSC_SDK` environment variable configured (and `GSC_SDK_CORE` for builds targeting .NET 8 or later, available in Security Center 5.13+).
 - **Visual Studio 2022**: Version 17.6 or later for development (must run as Administrator)
 - **Security Center**: Installed and running on your system
 - **Valid Security Center License**: All samples include the development SDK certificate
@@ -513,7 +513,7 @@ By properly implementing the `GetSpecificCreationScript` method, you ensure that
 
 #### Overview
 
-`DatabaseUpgradeItem` is a important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
+`DatabaseUpgradeItem` is an important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
 
 #### Purpose
 
@@ -664,7 +664,7 @@ public override void DatabaseCleanup(string name, int retentionPeriod)
 
 #### Integration with Security Center
 
-By implementing `DatabaseCleanupThreshold` allows the plugin to:
+Implementing `DatabaseCleanupThreshold` allows the plugin to:
 
 - View and modify retention periods for different types of data
 - Schedule cleanup operations according to the plugin configuration


### PR DESCRIPTION
This pull request updates documentation to clarify and expand support for .NET 8 and later in the Plugin SDK, including new requirements and guidance for building plugins targeting different runtimes. The most important changes are:

**.NET 8 and Plugin SDK Support Updates:**

* Updated the main `README.md` to indicate that the Plugin SDK now supports .NET 8 for the `ServerModule` component, provided Security Center 5.13+ is used. The `ClientModule` continues to require .NET Framework, and a link to detailed guidance has been added.
* Revised the Plugin SDK sample's `README.md` to reflect support for .NET Framework 4.8.1, .NET 8 (Security Center 5.13+), and .NET 10 (Security Center 5.14.1+), with clear distinctions between `ServerModule` and `ClientModule` targeting requirements.

**SDK and Environment Variable Requirements:**

* Clarified that, for builds targeting .NET 8 or later, the `GSC_SDK_CORE` environment variable is required, and this is available only in Security Center 5.13 or later.

These changes help developers understand the expanded runtime support and updated prerequisites for building plugins with the Plugin SDK.