### PR TITLE
chore: align non-Platform SDK sample targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ The following table shows which .NET frameworks are supported by each SDK:
 | **Platform SDK** | ✅ | ✅ | .NET 8 requires Security Center SDK 5.12.2+ |
 | **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
 | **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
-| **Plugin SDK** | ✅ | ❌ | .NET 8 support planned for future release |
+| **Plugin SDK** | ✅ | ✅ | .NET 8 support for the `ServerModule` requires Security Center 5.13+. The `ClientModule` (Config Tool / Security Desk UI) targets .NET Framework only. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8). |
 
-**Important**: Only Platform SDK samples support multi-targeting. All other SDK samples target .NET Framework 4.8.1 exclusively.
+**Important**: Only Platform SDK samples in this repository are configured to multi-target. The Plugin, Workspace, and Media SDK samples target .NET Framework 4.8.1 exclusively, even where the SDK itself supports additional runtimes (see Plugin SDK row above).
 
   
 

--- a/Samples/Media SDK/AudioRecorderSample/AudioRecorderSample.csproj
+++ b/Samples/Media SDK/AudioRecorderSample/AudioRecorderSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/AudioTransmitterSample/AudioTransmitterSample.csproj
+++ b/Samples/Media SDK/AudioTransmitterSample/AudioTransmitterSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>True</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
+++ b/Samples/Media SDK/FileCryptingManagerSample/FileCryptingManagerSample.csproj
@@ -50,18 +50,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
+++ b/Samples/Media SDK/MediaFileSample/MediaFileSample.csproj
@@ -50,18 +50,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/MediaPlayerSample/MediaPlayerSample.csproj
+++ b/Samples/Media SDK/MediaPlayerSample/MediaPlayerSample.csproj
@@ -52,19 +52,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/OverlaySample/OverlaySample.csproj
+++ b/Samples/Media SDK/OverlaySample/OverlaySample.csproj
@@ -51,19 +51,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
+++ b/Samples/Media SDK/PlaybackSequenceQuerierSample/PlaybackSequenceQuerierSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
+++ b/Samples/Media SDK/PlaybackStreamReaderSample/PlaybackStreamReaderSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
+++ b/Samples/Media SDK/PtzCoordinatesManagerSample/PtzCoordinatesManagerSample.csproj
@@ -48,19 +48,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/VideoConverterSample/VideoConverterSample.csproj
+++ b/Samples/Media SDK/VideoConverterSample/VideoConverterSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
+++ b/Samples/Media SDK/VideoExportSample/VideoExportSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
+++ b/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.csproj
@@ -47,19 +47,6 @@
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Media">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Media.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Plugin SDK/BasicPluginTemplate/BasicPluginTemplate.csproj
+++ b/Samples/Plugin SDK/BasicPluginTemplate/BasicPluginTemplate.csproj
@@ -47,19 +47,6 @@
 		<Reference Include="System.Core" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Plugin SDK/CustomActionSample/CustomActionSample.csproj
+++ b/Samples/Plugin SDK/CustomActionSample/CustomActionSample.csproj
@@ -59,27 +59,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Prism.Core" Version="8.1.97" />
 	  <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />

--- a/Samples/Plugin SDK/CustomReportSample/CustomReportSample.csproj
+++ b/Samples/Plugin SDK/CustomReportSample/CustomReportSample.csproj
@@ -60,27 +60,6 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <Resource Include="Resources\Images\LargeLogo.png" />
 	  <Resource Include="Resources\Images\SmallLogo.png" />

--- a/Samples/Plugin SDK/PluginConfigurationSample/PluginConfigurationSample.csproj
+++ b/Samples/Plugin SDK/PluginConfigurationSample/PluginConfigurationSample.csproj
@@ -59,27 +59,6 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Reactive" Version="6.0.1" />

--- a/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
+++ b/Samples/Plugin SDK/PluginDatabaseSample/PluginDatabaseSample.csproj
@@ -47,19 +47,6 @@
 		<Reference Include="System.Core" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Plugin.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 	</ItemGroup>

--- a/Samples/Plugin SDK/README.md
+++ b/Samples/Plugin SDK/README.md
@@ -52,8 +52,8 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 
 ## Prerequisites
 
-- **.NET Framework 4.8.1**: The Plugin SDK only supports the .NET Framework; it does not support .NET 8 yet.
-- **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
+- **.NET Framework 4.8.1 or .NET 8**: The Plugin SDK supports both runtimes. A plugin's `ServerModule` (the role logic) can target .NET Framework 4.8.1 (any Security Center version), .NET 8 (Security Center 5.13 or later), or .NET 10 (Security Center 5.14.1 or later). The `ClientModule`, when present, must target .NET Framework 4.8.1 because Config Tool and Security Desk run on .NET Framework. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8) for project-structure options.
+- **Security Center SDK**: Installed with the `GSC_SDK` environment variable configured (and `GSC_SDK_CORE` for builds targeting .NET 8 or later, available in Security Center 5.13+).
 - **Visual Studio 2022**: Version 17.6 or later for development (must run as Administrator)
 - **Security Center**: Installed and running on your system
 - **Valid Security Center License**: All samples include the development SDK certificate
@@ -513,7 +513,7 @@ By properly implementing the `GetSpecificCreationScript` method, you ensure that
 
 #### Overview
 
-`DatabaseUpgradeItem` is a important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
+`DatabaseUpgradeItem` is an important component for managing database schema evolution in your plugin. It allows you to define and execute database upgrades smoothly as your plugin evolves across different versions.
 
 #### Purpose
 
@@ -664,7 +664,7 @@ public override void DatabaseCleanup(string name, int retentionPeriod)
 
 #### Integration with Security Center
 
-By implementing `DatabaseCleanupThreshold` allows the plugin to:
+Implementing `DatabaseCleanupThreshold` allows the plugin to:
 
 - View and modify retention periods for different types of data
 - Schedule cleanup operations according to the plugin configuration

--- a/Samples/Workspace SDK/BackgroundProcessSample/BackgroundProcessSample.csproj
+++ b/Samples/Workspace SDK/BackgroundProcessSample/BackgroundProcessSample.csproj
@@ -54,23 +54,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/BadgePrinterSample/BadgePrinterSample.csproj
+++ b/Samples/Workspace SDK/BadgePrinterSample/BadgePrinterSample.csproj
@@ -57,23 +57,6 @@
 		<Reference Include="System.Drawing" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/CardholderCredentialReaderSample/CardholderCredentialReaderSample.csproj
+++ b/Samples/Workspace SDK/CardholderCredentialReaderSample/CardholderCredentialReaderSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/CardholderFieldsExtractorSample/CardholderFieldsExtractorSample.csproj
+++ b/Samples/Workspace SDK/CardholderFieldsExtractorSample/CardholderFieldsExtractorSample.csproj
@@ -49,19 +49,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Workspace SDK/CommandManagerSample/CommandManagerSample.csproj
+++ b/Samples/Workspace SDK/CommandManagerSample/CommandManagerSample.csproj
@@ -49,19 +49,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 	  <Exec Command="REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v Enabled /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v ClientModule /t REG_SZ /d &quot;$(TargetPath)&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v AddFoldersToAssemblyProbe /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v Enabled /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v ClientModule /t REG_SZ /d &quot;$(TargetPath)&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v AddFoldersToAssemblyProbe /t REG_SZ /d &quot;True&quot; /f" />
 	</Target>

--- a/Samples/Workspace SDK/ConfigPageSample/ConfigPageSample.csproj
+++ b/Samples/Workspace SDK/ConfigPageSample/ConfigPageSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <Resource Include="Resources\Images\LargeLogo.png" />
 	  <Resource Include="Resources\Images\SmallLogo.png" />

--- a/Samples/Workspace SDK/ContextualActionSample/ContextualActionSample.csproj
+++ b/Samples/Workspace SDK/ContextualActionSample/ContextualActionSample.csproj
@@ -50,19 +50,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<Exec Command="REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v Enabled /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v ClientModule /t REG_SZ /d &quot;$(TargetPath)&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v AddFoldersToAssemblyProbe /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v Enabled /t REG_SZ /d &quot;True&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v ClientModule /t REG_SZ /d &quot;$(TargetPath)&quot; /f&#xD;&#xA;REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Plugins\$(ProjectName)&quot; /v AddFoldersToAssemblyProbe /t REG_SZ /d &quot;True&quot; /f" />

--- a/Samples/Workspace SDK/ControlsSample/ControlsSample.csproj
+++ b/Samples/Workspace SDK/ControlsSample/ControlsSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/CredentialReaderSample/CredentialReaderSample.csproj
+++ b/Samples/Workspace SDK/CredentialReaderSample/CredentialReaderSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/DashboardWidgetSample/DashboardWidgetSample.csproj
+++ b/Samples/Workspace SDK/DashboardWidgetSample/DashboardWidgetSample.csproj
@@ -56,19 +56,6 @@
 		<Reference Include="System.Xml" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Prism.Core" Version="8.1.97" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/EventExtenderSample/EventExtenderSample.csproj
+++ b/Samples/Workspace SDK/EventExtenderSample/EventExtenderSample.csproj
@@ -49,19 +49,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/ImageExtractorSample/ImageExtractorSample.csproj
+++ b/Samples/Workspace SDK/ImageExtractorSample/ImageExtractorSample.csproj
@@ -50,19 +50,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/OptionsExtensionSample/OptionsExtensionSample.csproj
+++ b/Samples/Workspace SDK/OptionsExtensionSample/OptionsExtensionSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
 	</ItemGroup>

--- a/Samples/Workspace SDK/PageTaskSample/PageTaskSample.csproj
+++ b/Samples/Workspace SDK/PageTaskSample/PageTaskSample.csproj
@@ -58,23 +58,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Workspace SDK/TaskSample/TaskSample.csproj
+++ b/Samples/Workspace SDK/TaskSample/TaskSample.csproj
@@ -50,19 +50,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<ItemGroup>
 	  <Resource Include="Resources\Icon.png" />
 	  <Resource Include="Resources\Thumbnail.png" />

--- a/Samples/Workspace SDK/TilePropertiesSample/TilePropertiesSample.csproj
+++ b/Samples/Workspace SDK/TilePropertiesSample/TilePropertiesSample.csproj
@@ -49,22 +49,6 @@
 		</Reference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.6" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<Reference Include="System" />
 		<Reference Include="System.Core" />

--- a/Samples/Workspace SDK/TileViewSample/TileViewSample.csproj
+++ b/Samples/Workspace SDK/TileViewSample/TileViewSample.csproj
@@ -54,23 +54,6 @@
 		<Reference Include="WindowsBase" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Workspace SDK/TileWidgetSample/TileWidgetSample.csproj
+++ b/Samples/Workspace SDK/TileWidgetSample/TileWidgetSample.csproj
@@ -55,23 +55,6 @@
 		<Reference Include="System.Drawing" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Controls">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Controls.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
-
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>
 			<CertOutputPath>$(OutputPath)Certificates</CertOutputPath>

--- a/Samples/Workspace SDK/TimelineProviderSample/TimelineProviderSample.csproj
+++ b/Samples/Workspace SDK/TimelineProviderSample/TimelineProviderSample.csproj
@@ -49,19 +49,6 @@
 		<Reference Include="WindowsBase" />
 		<Reference Include="System.Data.DataSetExtensions" />
 	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<Reference Include="Genetec.Sdk">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<Reference Include="Genetec.Sdk.Workspace">
-			<HintPath>$(GSC_SDK_CORE)\Genetec.Sdk.Workspace.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.8" />
-		<FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-	</ItemGroup>
 		
 	<Target Name="CopyCertificates" AfterTargets="Build">
 		<PropertyGroup>


### PR DESCRIPTION
## Summary
- Remove inactive `net8.0-windows` ItemGroups from Media SDK, Workspace SDK, and Plugin SDK sample projects that only target `net481`.
- Clarify Plugin SDK runtime support in the root README and Plugin SDK README: server modules can target .NET 8+ in supported Security Center versions, while the repository sample csprojs remain `net481`.
- Keep Platform SDK multi-targeting and configuration changes separate in #185.