### PR TITLE
Fix DAP sample async and event-handling robustness issues

### DIFF
--- a/Samples/Media SDK/MediaPlayerSample/MediaPlayerSample.cs
+++ b/Samples/Media SDK/MediaPlayerSample/MediaPlayerSample.cs
@@ -208,7 +208,7 @@ public class MediaPlayerSample : SampleBase
 
         void OpenFile()
         {
-            OpenFileDialog openFileDialog = new() { Filter = "Video files (*.mp4;*..g64;*..g64x)|*.mp4;*.g64;*..g64x|All files (*.*)|*.*" };
+            OpenFileDialog openFileDialog = new() { Filter = "Video files (*.mp4;*.g64;*.g64x)|*.mp4;*.g64;*.g64x|All files (*.*)|*.*" };
             if (openFileDialog.ShowDialog().GetValueOrDefault())
             {
                 player.OpenFile(openFileDialog.FileName);

--- a/Samples/Media SDK/OverlaySample/OverlayExtensions.cs
+++ b/Samples/Media SDK/OverlaySample/OverlayExtensions.cs
@@ -3,14 +3,15 @@
 
 namespace Genetec.Dap.CodeSamples;
 
+using System.Threading;
 using System.Threading.Tasks;
 using Sdk.Media.Overlay;
 
 public static class OverlayExtensions
 {
-    public static async Task WaitUntilReadyForUpdate(this Overlay overlay)
+    public static async Task WaitUntilReadyForUpdate(this Overlay overlay, CancellationToken cancellationToken = default)
     {
-        var completion = new TaskCompletionSource<object>();
+        var completion = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         overlay.StateChange += OnStateChange;
         try
@@ -20,7 +21,10 @@ public static class OverlayExtensions
                 return;
             }
 
-            await completion.Task;
+            using (cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken)))
+            {
+                await completion.Task;
+            }
         }
         finally
         {
@@ -31,7 +35,7 @@ public static class OverlayExtensions
         {
             if (e.CanPropagateUpdate)
             {
-                completion.SetResult(null);
+                completion.TrySetResult(null);
             }
         }
     }

--- a/Samples/Media SDK/OverlaySample/OverlaySample.cs
+++ b/Samples/Media SDK/OverlaySample/OverlaySample.cs
@@ -51,7 +51,7 @@ public class OverlaySample : SampleBase
     {
         const string layerId = "69A64ACE-6DDC-4142-AD04-06690D8591B3"; // Replace with a unique layer ID for your overlay. Layer ID must be unique and deterministic
 
-        Overlay overlay = await InitializeOverlay(cameraId, "Bouncing ball");
+        Overlay overlay = await InitializeOverlay(cameraId, "Bouncing ball", token);
         Layer layer = overlay.CreateLayer(new Guid(layerId), "Bouncing ball");
 
         var bouncingBall = new BouncingBall(50, 50, 50, 50, 25) { CanvasHeight = s_canvasHeight, CanvasWidth = s_canvasWidth };
@@ -73,7 +73,7 @@ public class OverlaySample : SampleBase
     {
         const string layerId = "92AEA5CA-E0F5-4122-872A-DB9A9F7437F7"; // Replace with a unique layer ID for your overlay. Layer ID must be unique and deterministic
 
-        Overlay overlay = await InitializeOverlay(cameraId, "Timecode");
+        Overlay overlay = await InitializeOverlay(cameraId, "Timecode", token);
         Layer layer = overlay.CreateLayer(new Guid(layerId), "Timecode");
 
         var timeDisplay = new TimeDisplay();
@@ -95,7 +95,7 @@ public class OverlaySample : SampleBase
     {
         const string layerId = "A1B2C3D4-E5F6-7890-1234-567890ABCDEF"; // Replace with a unique layer ID for your overlay. Layer ID must be unique and deterministic
 
-        Overlay overlay = await InitializeOverlay(camera.Guid, "Recording Status");
+        Overlay overlay = await InitializeOverlay(camera.Guid, "Recording Status", token);
         Layer layer = overlay.CreateLayer(new Guid(layerId), "Recording Status");
 
         var recordingStatus = new RecordingStatus(camera);
@@ -113,7 +113,7 @@ public class OverlaySample : SampleBase
         }
     }
 
-    private async Task<Overlay> InitializeOverlay(Guid camera, string overlayName)
+    private async Task<Overlay> InitializeOverlay(Guid camera, string overlayName, CancellationToken token)
     {
         Overlay overlay = OverlayFactory.Get(camera, overlayName);
 
@@ -122,7 +122,7 @@ public class OverlaySample : SampleBase
             overlay.Initialize(s_canvasHeight, s_canvasWidth);
         }
 
-        await overlay.WaitUntilReadyForUpdate();
+        await overlay.WaitUntilReadyForUpdate(token);
         return overlay;
     }
 }

--- a/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.cs
+++ b/Samples/Media SDK/VideoSourceFilterSample/VideoSourceFilterSample.cs
@@ -37,7 +37,7 @@ public class VideoSourceFilterSample : SampleBase
 
     private async Task<byte[]> GetCameraSnapshot(Engine engine, Guid camera)
     {
-        var completion = new TaskCompletionSource<byte[]>();
+        var completion = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using (var videoSourceFilter = new VideoSourceFilter())
         {
@@ -52,6 +52,7 @@ public class VideoSourceFilterSample : SampleBase
             finally
             {
                 videoSourceFilter.FrameDecoded -= OnFrameDecoded;
+                videoSourceFilter.PlayerStateChanged -= OnPlayerStateChanged;
                 videoSourceFilter.Stop();
             }
         }
@@ -75,7 +76,8 @@ public class VideoSourceFilterSample : SampleBase
                 }
                 catch (Exception ex)
                 {
-                    completion.SetException(ex);
+                    completion.TrySetException(ex);
+                    return;
                 }
 
                 memoryStream.Position = 0;

--- a/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.cs
+++ b/Samples/Platform SDK/AccessVerifierSample/AccessVerifierSample.cs
@@ -18,9 +18,14 @@ public class AccessVerifierSample : SampleBase
     protected override async Task RunAsync(Engine engine, CancellationToken token)
     {
         // Load the specified entity types into the entity cache
-        await LoadEntities(engine, token, EntityType.Credential, EntityType.AccessPoint, EntityType.Schedule, EntityType.AccessRule);
+        await LoadEntities(engine, token, EntityType.Credential, EntityType.AccessPoint, EntityType.Schedule, EntityType.AccessRule, EntityType.Door);
 
         List<Guid> doorGuids = engine.GetEntities(EntityType.Door).Select(door => door.Guid).ToList();
+        if (doorGuids.Count == 0)
+        {
+            Console.WriteLine("No doors were found. The access matrix cannot be generated.");
+            return;
+        }
 
         DateTime currentTime = DateTime.UtcNow;
 

--- a/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.cs
+++ b/Samples/Platform SDK/VideoUnitSample/VideoUnitSample.cs
@@ -120,7 +120,7 @@ public class VideoUnitSample : SampleBase
 
     private async Task<Guid> AddVideoUnit(IVideoUnitManager videoUnitManager, AddVideoUnitInfo videoUnitInfo, Guid archiver, IProgress<EnrollmentResult> progress = default)
     {
-        var completion = new TaskCompletionSource<Guid>();
+        var completion = new TaskCompletionSource<Guid>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         videoUnitManager.EnrollmentStatusChanged += OnEnrollmentStatusChanged;
         try
@@ -136,19 +136,36 @@ public class VideoUnitSample : SampleBase
 
         void OnEnrollmentStatusChanged(object sender, UnitEnrolledEventArgs e)
         {
+            if (!IsEnrollmentForRequestedUnit(e))
+            {
+                return;
+            }
+
             progress?.Report(e.EnrollmentResult);
 
             if (e.EnrollmentResult != EnrollmentResult.Connecting)
             {
                 if (e.Unit != Guid.Empty)
                 {
-                    completion.SetResult(e.Unit);
+                    completion.TrySetResult(e.Unit);
                 }
                 else
                 {
-                    completion.SetException(new Exception($"Unable to enroll the video unit: {e.EnrollmentResult}"));
+                    completion.TrySetException(new Exception($"Unable to enroll the video unit: {e.EnrollmentResult}"));
                 }
             }
+        }
+
+        bool IsEnrollmentForRequestedUnit(UnitEnrolledEventArgs e)
+        {
+            string expectedAddress = videoUnitInfo.Hostname ?? videoUnitInfo.IPEndPoint?.Address.ToString();
+            if (!string.IsNullOrWhiteSpace(expectedAddress) && !string.Equals(e.Address, expectedAddress, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            int expectedPort = videoUnitInfo.Port;
+            return expectedPort < 0 || e.Port == expectedPort;
         }
     }
 }

--- a/Samples/Plugin SDK/CustomReportSample/AsyncEnumerableExtensions.cs
+++ b/Samples/Plugin SDK/CustomReportSample/AsyncEnumerableExtensions.cs
@@ -3,9 +3,11 @@
 
 namespace Genetec.Dap.CodeSamples;
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 
 public static class AsyncEnumerableExtensions
 {
@@ -16,25 +18,30 @@ public static class AsyncEnumerableExtensions
     /// <param name="source">The source <see cref="IAsyncEnumerable{T}"/> to buffer.</param>
     /// <param name="bufferSize">The size of each buffer.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>An <see cref="IAsyncEnumerable{T}"/> of <see cref="IAsyncEnumerable{T}"/> representing the buffered elements.</returns>
-    public static async IAsyncEnumerable<IAsyncEnumerable<T>> Buffer<T>(this IAsyncEnumerable<T> source, int bufferSize, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    /// <returns>An <see cref="IAsyncEnumerable{T}"/> of <see cref="IReadOnlyList{T}"/> representing the buffered elements.</returns>
+    public static async IAsyncEnumerable<IReadOnlyList<T>> Buffer<T>(this IAsyncEnumerable<T> source, int bufferSize, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        await using IAsyncEnumerator<T> enumerator = source.GetAsyncEnumerator(cancellationToken);
-        while (await enumerator.MoveNextAsync())
+        if (bufferSize <= 0)
         {
-            yield return BufferInternal();
+            throw new ArgumentOutOfRangeException(nameof(bufferSize));
         }
 
-        async IAsyncEnumerable<T> BufferInternal()
-        {
-            for (var i = 0; i < bufferSize; i++)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+        var batch = new List<T>(bufferSize);
 
-                yield return enumerator.Current;
-                if (!await enumerator.MoveNextAsync())
-                    yield break;
+        await foreach (T item in source.WithCancellation(cancellationToken))
+        {
+            batch.Add(item);
+
+            if (batch.Count == bufferSize)
+            {
+                yield return batch;
+                batch = new List<T>(bufferSize);
             }
+        }
+
+        if (batch.Count > 0)
+        {
+            yield return batch;
         }
     }
 }

--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/ActivityTrailsReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/ActivityTrailsReportHandler.cs
@@ -19,9 +19,9 @@ public class ActivityTrailsReportHandler : ReportHandler<ActivityTrailsQuery, Ac
     {
     }
 
-    protected override async Task ProcessBatch(DataTable table, IAsyncEnumerable<ActivityTrailRow> batch)
+    protected override void ProcessBatch(DataTable table, IReadOnlyList<ActivityTrailRow> batch)
     {
-        await foreach (ActivityTrailRow row in batch)
+        foreach (ActivityTrailRow row in batch)
         {
             table.AddIRow(row);
         }

--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/AuditTrailsReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/AuditTrailsReportHandler.cs
@@ -19,9 +19,9 @@ public class AuditTrailsReportHandler : ReportHandler<AuditTrailQuery, AuditTrai
     {
     }
 
-    protected override async Task ProcessBatch(DataTable table, IAsyncEnumerable<AuditTrailRow> batch)
+    protected override void ProcessBatch(DataTable table, IReadOnlyList<AuditTrailRow> batch)
     {
-        await foreach (AuditTrailRow row in batch)
+        foreach (AuditTrailRow row in batch)
         {
             table.AddIRow(row);
         }

--- a/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/ReportHandler.cs
+++ b/Samples/Plugin SDK/CustomReportSample/Server/ReportHandlers/ReportHandler.cs
@@ -45,12 +45,12 @@ public abstract class ReportHandler<TQuery, TRecord> : IReportHandler, IDisposab
             int totalSent = 0;
             int maxResults = args.Query.MaximumResultCount;
 
-            await foreach (IAsyncEnumerable<TRecord> batch in records.Buffer(GetBatchSize()).WithCancellation(token))
+            await foreach (IReadOnlyList<TRecord> batch in records.Buffer(GetBatchSize()).WithCancellation(token))
             {
                 token.ThrowIfCancellationRequested();
 
                 DataTable table = CreateDataTable(query);
-                await ProcessBatch(table, batch);
+                ProcessBatch(table, batch);
                 SendQueryResult(args, table);
 
                 totalSent += table.Rows.Count;
@@ -72,9 +72,9 @@ public abstract class ReportHandler<TQuery, TRecord> : IReportHandler, IDisposab
         return query.GetNewDataTables().First();
     }
 
-    protected virtual async Task ProcessBatch(DataTable table, IAsyncEnumerable<TRecord> batch)
+    protected virtual void ProcessBatch(DataTable table, IReadOnlyList<TRecord> batch)
     {
-        await foreach (TRecord record in batch)
+        foreach (TRecord record in batch)
         {
             if (record is IRow row)
             {

--- a/Samples/Workspace SDK/TimelineProviderSample/AccessControlTimelineProvider.cs
+++ b/Samples/Workspace SDK/TimelineProviderSample/AccessControlTimelineProvider.cs
@@ -3,6 +3,7 @@
 
 namespace Genetec.Dap.CodeSamples;
 
+using Genetec.Sdk.Diagnostics.Logging.Core;
 using Sdk;
 using Sdk.Events.AccessPoint;
 using Sdk.Queries;
@@ -17,37 +18,49 @@ using System.Threading.Tasks;
 
 public class AccessControlTimelineProvider : TimelineProvider, IDisposable
 {
+    private readonly Logger m_logger;
     private readonly Workspace m_workspace;
 
     public AccessControlTimelineProvider(Workspace workspace)
     {
+        m_logger = Logger.CreateInstanceLogger(this);
         m_workspace = workspace;
         m_workspace.Sdk.EventReceived += OnEventReceived;
     }
 
     public override void Query(ContentGroup contentGroup, DateTime startTime, DateTime endTime)
     {
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
-            var query = (CardholderActivityQuery)m_workspace.Sdk.ReportManager.CreateReportQuery(ReportType.CardholderActivity);
-            query.TimeRange.SetTimeRange(startTime, endTime);
-            query.Events.Clear();
-            query.Events.Add(EventType.AccessGranted);
-            query.Events.Add(EventType.AccessRefused);
-
-            QueryCompletedEventArgs result = await Task.Factory.FromAsync(query.BeginQuery, query.EndQuery, null);
-
-            var events = result.Data.AsEnumerable().Select(row =>
+            try
             {
-                var timestamp = row.Field<DateTime>(AccessControlReportQuery.TimestampColumnName);
-                var cardholderGuid = row.Field<Guid>(AccessControlReportQuery.CardholderGuidColumnName);
-                var eventType = row.Field<EventType>(AccessControlReportQuery.EventTypeColumnName);
+                var query = (CardholderActivityQuery)m_workspace.Sdk.ReportManager.CreateReportQuery(ReportType.CardholderActivity);
+                query.TimeRange.SetTimeRange(startTime, endTime);
+                query.Events.Clear();
+                query.Events.Add(EventType.AccessGranted);
+                query.Events.Add(EventType.AccessRefused);
 
-                return new AccessTimelineEvent(cardholderGuid, timestamp, eventType == EventType.AccessGranted);
-            });
+                QueryCompletedEventArgs result = await Task.Factory.FromAsync(query.BeginQuery, query.EndQuery, null);
 
-            InsertEvents(events);
-            OnQueryCompleted();
+                var events = result.Data.AsEnumerable().Select(row =>
+                {
+                    var timestamp = row.Field<DateTime>(AccessControlReportQuery.TimestampColumnName);
+                    var cardholderGuid = row.Field<Guid>(AccessControlReportQuery.CardholderGuidColumnName);
+                    var eventType = row.Field<EventType>(AccessControlReportQuery.EventTypeColumnName);
+
+                    return new AccessTimelineEvent(cardholderGuid, timestamp, eventType == EventType.AccessGranted);
+                });
+
+                InsertEvents(events);
+            }
+            catch (Exception ex)
+            {
+                m_logger.TraceError(ex, $"Failed to query access control timeline events: {ex.Message}");
+            }
+            finally
+            {
+                OnQueryCompleted();
+            }
         });
     }
 
@@ -72,5 +85,6 @@ public class AccessControlTimelineProvider : TimelineProvider, IDisposable
     public void Dispose()
     {
         m_workspace.Sdk.EventReceived -= OnEventReceived;
+        m_logger.Dispose();
     }
 }

--- a/Samples/Workspace SDK/TimelineProviderSample/AlarmTimelineProvider.cs
+++ b/Samples/Workspace SDK/TimelineProviderSample/AlarmTimelineProvider.cs
@@ -3,6 +3,7 @@
 
 namespace Genetec.Dap.CodeSamples;
 
+using Genetec.Sdk.Diagnostics.Logging.Core;
 using System;
 using System.Data;
 using System.Linq;
@@ -15,44 +16,57 @@ using Sdk.Workspace.Pages.Contents;
 
 public class AlarmTimelineProvider : TimelineProvider, IDisposable
 {
+    private readonly Logger m_logger;
     private readonly Workspace m_workspace;
 
     public AlarmTimelineProvider(Workspace workspace)
     {
+        m_logger = Logger.CreateInstanceLogger(this);
         m_workspace = workspace;
         m_workspace.Sdk.AlarmAcknowledged += OnAlarmAcknowledged;
     }
 
     public override void Query(ContentGroup contentGroup, DateTime startTime, DateTime endTime)
     {
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
-            var query = (AlarmActivityQuery)m_workspace.Sdk.ReportManager.CreateReportQuery(ReportType.AlarmActivity);
-            query.TriggeredTimeRange.SetTimeRange(startTime, endTime);
-            query.States.Add(AlarmState.Active);
-            query.States.Add(AlarmState.AknowledgeRequired);
-            query.States.Add(AlarmState.SourceConditionInvestigating);
-
-            QueryCompletedEventArgs result = await Task.Factory.FromAsync(query.BeginQuery, query.EndQuery, null);
-
-            var events = result.Data.AsEnumerable().Select(row =>
+            try
             {
-                var alarmGuid = row.Field<Guid>(AlarmActivityQuery.AlarmColumnName);
-                var instanceId = row.Field<int>(AlarmActivityQuery.InstanceIdColumnName);
-                var triggerTime = row.Field<DateTime>(AlarmActivityQuery.TriggerTimeColumnName);
+                var query = (AlarmActivityQuery)m_workspace.Sdk.ReportManager.CreateReportQuery(ReportType.AlarmActivity);
+                query.TriggeredTimeRange.SetTimeRange(startTime, endTime);
+                query.States.Add(AlarmState.Active);
+                query.States.Add(AlarmState.AknowledgeRequired);
+                query.States.Add(AlarmState.SourceConditionInvestigating);
 
-                return new AlarmTimelineEvent(alarmGuid, instanceId, triggerTime);
-            });
+                QueryCompletedEventArgs result = await Task.Factory.FromAsync(query.BeginQuery, query.EndQuery, null);
 
-            InsertEvents(events);
-            OnQueryCompleted();
+                var events = result.Data.AsEnumerable().Select(row =>
+                {
+                    var alarmGuid = row.Field<Guid>(AlarmActivityQuery.AlarmColumnName);
+                    var instanceId = row.Field<int>(AlarmActivityQuery.InstanceIdColumnName);
+                    var triggerTime = row.Field<DateTime>(AlarmActivityQuery.TriggerTimeColumnName);
+
+                    return new AlarmTimelineEvent(alarmGuid, instanceId, triggerTime);
+                });
+
+                InsertEvents(events);
+            }
+            catch (Exception ex)
+            {
+                m_logger.TraceError(ex, $"Failed to query alarm timeline events: {ex.Message}");
+            }
+            finally
+            {
+                OnQueryCompleted();
+            }
         });
     }
 
     private void OnAlarmAcknowledged(object sender, AlarmAcknowledgedEventArgs e)
     {
         foreach (AlarmTimelineEvent timelineEvent in GetEvents().OfType<AlarmTimelineEvent>()
-                     .Where(t => t.AlarmGuid == e.AlarmGuid && t.InstanceId == e.InstanceId))
+                     .Where(t => t.AlarmGuid == e.AlarmGuid && t.InstanceId == e.InstanceId)
+                     .ToList())
         {
             RemoveEvent(timelineEvent);
         }
@@ -61,5 +75,6 @@ public class AlarmTimelineProvider : TimelineProvider, IDisposable
     public void Dispose()
     {
         m_workspace.Sdk.AlarmAcknowledged -= OnAlarmAcknowledged;
+        m_logger.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

- Fix `AsyncEnumerableExtensions.Buffer<T>` so consecutive batches do not skip records.
- Harden event-driven `TaskCompletionSource` usage in video unit, overlay, and video source filter samples.
- Load doors explicitly in `AccessVerifierSample` before querying access results.
- Log and complete fire-and-forget timeline report queries on failure.
- Fix the MediaPlayerSample `.g64x` open-file dialog filter.