### PR TITLE
fix: support .NET 6 and .NET 10 in the shared SDK resolver

### DIFF
--- a/Samples/Shared/SdkResolverNetCoreApp.cs
+++ b/Samples/Shared/SdkResolverNetCoreApp.cs
@@ -1,7 +1,7 @@
 // Copyright 2025 Genetec Inc.
 // Licensed under the Apache License, Version 2.0
 
-#if NET8_0_OR_GREATER
+#if NET6_0_OR_GREATER
 
 namespace Genetec.Dap.CodeSamples;
 
@@ -214,11 +214,20 @@ public static class SdkResolver
 
         foreach (var (_, folder) in GetInstallationFolders().OrderByDescending(t => t.Version))
         {
+#if NET10_0_OR_GREATER
+            var net10 = Path.Combine(folder, "net10.0-windows");
+            if (Directory.Exists(net10)) return net10;
+#endif
+
+#if NET8_0_OR_GREATER
             var net8 = Path.Combine(folder, "net8.0-windows");
             if (Directory.Exists(net8)) return net8;
+#endif
 
+#if NET6_0_OR_GREATER
             var net6 = Path.Combine(folder, "net6.0-windows");
             if (Directory.Exists(net6)) return net6;
+#endif
         }
 
         return null;


### PR DESCRIPTION
The shared resolver is excluded from .NET 6 builds, and registry fallback cannot find SDK installations containing only net10.0-windows assemblies.

Include the resolver in .NET 6 and later builds. Search the .NET 10, 8, and 6 folders in that order within each installation, with each search guarded by its matching target-framework symbol. Preserve installation-version ordering and explicit GSC_SDK_CORE overrides.