### PR TITLE
docs: clarify SDK runtime and sample setup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   
 
-This repository contains sample projects using the Security Center SDK. The samples demonstrate various features and capabilities of the **Security Center SDK**.
+This repository contains Security Center SDK samples for entity management, reports, events, media, plugin roles, and client extensions. It also includes Genetec Web Player hosting samples.
 
   
 
@@ -10,7 +10,7 @@ This repository contains sample projects using the Security Center SDK. The samp
 
   
 
-Security Center is Genetec's unified security platform that blends IP security systems within a single intuitive interface to simplify operations. It combines access control, video surveillance, automatic license plate recognition, communications, and analytics into one solution, enabling organizations to enhance their security operations and gain valuable insights.
+Security Center combines access control, video surveillance, automatic license plate recognition, communications, and analytics. Use its SDKs to build standalone integrations, server-side roles, and extensions for Security Desk and Config Tool.
 
   
 
@@ -37,19 +37,21 @@ Visit [Genetec's DAP](https://www.genetec.com/partners/sdk-dap) and join the pro
 -  **Install Security Center SDK**: The SDK contains the necessary libraries to build and run custom integrations. Download and install the Security Center SDK from the [Genetec Portal](https://www.genetec.com/portal).
 
    The SDK installer automatically:
-   - Creates environment variables (`GSC_SDK` for .NET Framework, `GSC_SDK_CORE` for .NET 8)
+   - Creates environment variables (`GSC_SDK` for .NET Framework, `GSC_SDK_CORE` for modern .NET)
    - Writes the installation path in Windows registry
    - Copies the Security Center SDK assemblies to the SDK directories
    
-   See [Referencing Security Center SDK Assemblies](https://github.com/Genetec/DAP/wiki/Referencing-Security-Center-SDK-Assemblies) for assembly referencing and runtime resolution details. 
+   See [Referencing Security Center SDK assemblies](https://github.com/Genetec/DAP/wiki/platform-sdk-referencing-assemblies) for assembly references, runtime resolution, and dependency deployment.
 
 -  **Development Tools**:
 
--  **Visual Studio**: Ensure you have Visual Studio 2022 version 17.6 (or later) installed.
+-  **Visual Studio**: Use Visual Studio 2022 version 17.8 or later for the existing samples. Use Visual Studio 2026 or later if you retarget a project to .NET 10.
 
--  **.NET Framework 4.8.1**: The sample projects can be built using .NET Framework 4.8.1, which is supported by all versions of Security Center.
+-  **.NET Framework targeting pack**: Install the .NET Framework 4.8.1 targeting pack for sample projects targeting `net481`.
 
 -  **.NET 8**: Some sample projects can be built using .NET 8. Platform SDK samples require **Security Center SDK 5.12.2 or later**; Plugin SDK .NET 8 support applies to server modules in **Security Center 5.13 or later**; Genetec Web Player samples target .NET 8 and do not use the .NET Security Center SDK.
+
+-  **.NET SDK**: Install the .NET 8 SDK or a later SDK that supports the sample's target. A project retargeted to .NET 10 requires the .NET 10 SDK or a later SDK that supports that target. Run `dotnet --list-sdks` to check installed SDKs.
 
   
 
@@ -128,7 +130,7 @@ See the [Media SDK README](Samples/Media%20SDK/README.md).
 
   
 
-Client-side user interface extensions that **leverage Platform SDK entities and services** to create custom components for Security Desk and Config Tool applications.
+Client-side user interface extensions that use Platform SDK entities and services to add components to Security Desk and Config Tool. These modules must target .NET Framework because they run inside the client applications.
 
   
 
@@ -265,19 +267,19 @@ The `_NET8` configurations require Security Center SDK 5.12.2 or later and `GSC_
 
 The Media SDK, Workspace SDK, and Plugin SDK sample projects in this repository target .NET Framework 4.8.1. The solution maps `Debug_NET8` and `Release_NET8` back to `Debug` and `Release` for those projects so that the solution configuration can focus on Platform SDK framework selection. The Genetec Web Player samples target .NET 8 and do not use the .NET Security Center SDK.
 
-## SDK Framework Support Matrix
+## Sample target frameworks
 
-The following table shows which .NET frameworks are supported by each SDK or sample group:
+This table describes the projects in this repository. SDK runtime support can extend beyond the targets configured in these samples.
 
-| SDK | .NET Framework 4.8.1 | .NET 8 | Notes |
-|-----|:-------------------:|:------:|-------|
-| **Genetec Web Player** | ❌ | ✅ | Targets .NET 8 only; ASP.NET Core or WPF + WebView2 |
-| **Platform SDK** | ✅ | ✅ | .NET 8 requires Security Center SDK 5.12.2+ |
-| **Media SDK** | ✅ | ❌ | .NET 8 support planned for future release |
-| **Workspace SDK** | ✅ | ❌ | Client applications use .NET Framework |
-| **Plugin SDK** | ✅ | ✅ | .NET 8 support for the `ServerModule` requires Security Center 5.13+. The `ClientModule` (Config Tool / Security Desk UI) targets .NET Framework only. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8). |
+| Sample group | Configured targets | Selection |
+|--------------|--------------------|-----------|
+| Platform SDK | `net481`, `net8.0-windows` | `Debug`/`Release` or `Debug_NET8`/`Release_NET8` |
+| Media SDK | `net481` | `Debug` or `Release` |
+| Workspace SDK | `net481` | `Debug` or `Release` |
+| Plugin SDK | `net481` | `Debug` or `Release` |
+| Genetec Web Player | `net8.0` for web projects; `net8.0-windows` for the desktop project | `Debug` or `Release` |
 
-**Important**: Only Platform SDK samples in this repository are configured to multi-target. The Plugin, Workspace, and Media SDK samples target .NET Framework 4.8.1 exclusively, even where the SDK itself supports additional runtimes (see Plugin SDK row above).
+The Platform SDK samples select one target per build configuration. The solution does not define a .NET 10 configuration. For guidance on retargeting your own application, see [Migrating a Platform SDK application to modern .NET](https://github.com/Genetec/DAP/wiki/platform-sdk-migrating-to-modern-dotnet).
 
   
 
@@ -291,6 +293,22 @@ Open `Samples/Genetec.Dap.CodeSamples.sln` and select one of the existing soluti
 Run Visual Studio as an administrator when building the full solution if you want Workspace SDK and Plugin SDK development registration to succeed.
 
   
+
+## Building modern .NET plugins
+
+The Plugin SDK samples in this repository target .NET Framework. For a modern .NET integration, choose the project and deployment instructions for the Security Center version where the role will run.
+
+### Security Center 5.14 and later
+
+Build a modern .NET ServerModule for server-side logic and an optional .NET Framework ClientModule for custom UI in Config Tool or Security Desk. Register the ServerModule on the server hosting the role and the ClientModule on workstations that use its UI. Security Center 5.14.0 supports .NET 8 role plugins; .NET 10 role hosting requires 5.14.1 or later.
+
+See [Building plugins for Security Center 5.14 and later](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8#security-center-514-and-later) and [Deploying plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-deployment#security-center-514-and-later), including the deployment requirement for modules that declare custom privileges.
+
+### Security Center 5.13
+
+Include a .NET Framework Client discovery assembly alongside the modern .NET ServerModule on the server. Config Tool requests the plugin list from that server. Keep any ClientModule targeting .NET Framework for its client-side UI.
+
+See [Building plugins for Security Center 5.13](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8#security-center-513) for the project structures and registration requirements.
 
 ## Documentation
 

--- a/Samples/Genetec Web Player/GwpDesktopPlayerSample/README.md
+++ b/Samples/Genetec Web Player/GwpDesktopPlayerSample/README.md
@@ -10,6 +10,10 @@ This sample demonstrates the feasible hosting model for the Genetec Web Player i
 
 ## Run
 
+Install the .NET 8 SDK and the Microsoft Edge WebView2 Runtime on Windows. This project targets `net8.0-windows` and runs as a standalone WPF application. It is not a module loaded by Security Desk or Config Tool.
+
+Configure the Media Gateway connection and certificate trust as described below, then run this command from the `GwpDesktopPlayerSample` folder:
+
 ```powershell
 dotnet run
 ```

--- a/Samples/Genetec Web Player/GwpMinimalApiSample/README.md
+++ b/Samples/Genetec Web Player/GwpMinimalApiSample/README.md
@@ -9,6 +9,8 @@ This sample demonstrates hosting the Genetec Web Player inside an ASP.NET Core M
 
 ## Run
 
+Install the .NET 8 SDK. This project targets `net8.0`. Configure the Media Gateway connection and certificate trust as described below, then run this command from the `GwpMinimalApiSample` folder:
+
 ```powershell
 dotnet run
 ```
@@ -69,7 +71,7 @@ The sample loads `gwp.js` from `${mediaGatewayEndpoint}/v2/files/gwp.js` so the 
 
 - This sample demonstrates a feasible hosting pattern. It is not a production-ready security design.
 - This sample has no user authentication. Anyone who can reach the application can view camera streams. A real application must add its own authentication layer to control who can access the application.
-- Media Gateway credentials are stored in `appsettings.json`. For production, use a secure configuration provider such as user secrets, Azure Key Vault, or environment variables.
+- Keep development credentials out of source control by using user secrets. For production, use a managed secret store such as Azure Key Vault. User secrets are intended for development.
 - The default SDK certificate is the Genetec development certificate intended for SDK development only.
 - A Content Security Policy meta tag restricts script sources, connections, and media to `self`, `https:`, `wss:`, and `blob:`. The policy allows `'unsafe-inline'` for scripts and styles because the page uses inline markup. The Razor Pages sample demonstrates how to use CSP nonces instead.
 - Player startup is cancellable. Clicking Stop during script load or session establishment cancels the in-flight start and cleans up any partially created player.

--- a/Samples/Genetec Web Player/GwpRazorPagesSample/README.md
+++ b/Samples/Genetec Web Player/GwpRazorPagesSample/README.md
@@ -1,6 +1,6 @@
 # GWP Razor Pages Sample
 
-This sample demonstrates hosting the Genetec Web Player inside an ASP.NET Core Razor Pages application with production-ready CSP nonce support:
+This sample demonstrates hosting the Genetec Web Player inside an ASP.NET Core Razor Pages application with Content Security Policy (CSP) nonces:
 
 - ASP.NET Core serves a Razor Page that loads and runs GWP.
 - The page is server-rendered, so the Media Gateway endpoint and server version are injected directly into the markup. No client-side configuration fetch is needed.
@@ -14,6 +14,8 @@ Compared to the Minimal API sample, this sample adds:
 - **Server-rendered configuration** injected directly into the Razor markup, removing the need for a separate `/api/config` endpoint.
 
 ## Run
+
+Install the .NET 8 SDK. This project targets `net8.0`. Configure the Media Gateway connection and certificate trust as described below, then run this command from the `GwpRazorPagesSample` folder:
 
 ```powershell
 dotnet run
@@ -86,7 +88,7 @@ Because the nonce is unique per request and cryptographically random, inline scr
 
 - This sample demonstrates a feasible hosting pattern. It is not a production-ready security design.
 - This sample has no user authentication. Anyone who can reach the application can view camera streams. A real application must add its own authentication layer to control who can access the application.
-- Media Gateway credentials are stored in `appsettings.json`. For production, use a secure configuration provider such as user secrets, Azure Key Vault, or environment variables.
+- Keep development credentials out of source control by using user secrets. For production, use a managed secret store such as Azure Key Vault. User secrets are intended for development.
 - The default SDK certificate is the Genetec development certificate intended for SDK development only.
 - Player startup is cancellable. Clicking Stop during script load or session establishment cancels the in-flight start and cleans up any partially created player.
 - Browser autoplay rules apply to audio.

--- a/Samples/Media SDK/README.md
+++ b/Samples/Media SDK/README.md
@@ -4,7 +4,7 @@ The Media SDK extends the Platform SDK with comprehensive video capabilities for
 
 ## Prerequisites
 
-- **.NET Framework 4.8.1**: The Media SDK only supports the .NET Framework; it does not support .NET 8 yet.  
+- **.NET Framework 4.8.1 targeting pack**: The Media SDK requires .NET Framework. The samples in this repository target .NET Framework 4.8.1.
 - **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
 - **Visual Studio 2022**: Version 17.6 or later for development
 - **Security Center**: Client applications (Security Desk and Config Tool) installed

--- a/Samples/Platform SDK/README.md
+++ b/Samples/Platform SDK/README.md
@@ -117,13 +117,17 @@ All samples follow consistent authentication patterns:
 - **Security Center SDK**: Installed with environment variables configured:
   - `GSC_SDK`: Points to SDK location for .NET Framework
   - `GSC_SDK_CORE`: Points to SDK location for .NET 8 (if using .NET 8)
-- **Visual Studio 2022**: Version 17.6 or later for development
-- **Security Center**: Installed and running on your system
+- **Visual Studio 2022**: Version 17.8 or later for the .NET 8 configurations
+- **Security Center**: A running system that you can connect to
 - **Valid Security Center License**: All samples include the development SDK certificate
 
 ### .NET 8 Compatibility
 
-The Platform SDK samples support both **.NET Framework 4.8.1** and **.NET 8**, but .NET 8 support requires **Security Center 5.12.2 or later**.
+The Platform SDK samples target **.NET Framework 4.8.1** or **.NET 8 for Windows**, depending on the build configuration. The .NET 8 configurations require **Security Center SDK 5.12.2 or later**.
+
+Install the .NET Framework 4.8.1 targeting pack for `net481`, or the .NET 8 SDK for `net8.0-windows`. Run `dotnet --list-sdks` to check the installed .NET SDKs.
+
+These projects do not include a .NET 10 build configuration. To retarget your own application, see [Migrating to modern .NET](https://github.com/Genetec/DAP/wiki/platform-sdk-migrating-to-modern-dotnet).
 
 #### Build Configuration Model
 
@@ -138,8 +142,8 @@ The projects use explicit build configurations for framework targeting:
 
 The build system checks these environment variables:
 
-- **`GSC_SDK`**: Points to .NET Framework SDK (legacy, works with all SC versions)
-- **`GSC_SDK_CORE`**: Points to .NET 8 SDK (requires SC 5.12.2+)
+- **`GSC_SDK`**: Points to the Security Center SDK assemblies for .NET Framework.
+- **`GSC_SDK_CORE`**: Points to the Security Center SDK assemblies for modern .NET. For these configurations, use the SDK's `net8.0-windows` folder.
 
 #### Technical Implementation
 
@@ -175,6 +179,8 @@ The build process includes automatic validation that:
 
 ### Building the Samples
 
+Run the following commands from an individual sample project folder, such as `Samples/Platform SDK/CardholderSample`.
+
 #### Default .NET Framework Build
 ```bash
 # Builds .NET Framework 4.8.1
@@ -196,7 +202,7 @@ dotnet run -c Debug_NET8
 ```
 
 ### Running a Sample
-1. **Update Connection Parameters**: Edit the hardcoded connection values in the sample to match your Security Center setup
+1. Edit the connection values in [SampleBase.cs](../Shared/SampleBase.cs) for samples that inherit from `SampleBase`. For other samples, edit their connection code.
 2. **Build and Run**: Use Visual Studio or the dotnet commands above to execute the sample
 3. **Observe the Output**: Each sample provides console output explaining what it's demonstrating
 

--- a/Samples/Plugin SDK/README.md
+++ b/Samples/Plugin SDK/README.md
@@ -52,12 +52,26 @@ By using the Plugin SDK, developers can create powerful, deeply integrated solut
 
 ## Prerequisites
 
-- **.NET Framework 4.8.1 or .NET 8**: The Plugin SDK supports both runtimes. A plugin's `ServerModule` (the role logic) can target .NET Framework 4.8.1 (any Security Center version), .NET 8 (Security Center 5.13 or later), or .NET 10 (Security Center 5.14.1 or later). The `ClientModule`, when present, must target .NET Framework 4.8.1 because Config Tool and Security Desk run on .NET Framework. See [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8) for project-structure options.
-- **Security Center SDK**: Installed with the `GSC_SDK` environment variable configured (and `GSC_SDK_CORE` for builds targeting .NET 8 or later, available in Security Center 5.13+).
+- **.NET Framework 4.8.1 targeting pack**: The Plugin SDK samples in this repository target `net481`. Selecting a solution configuration named `_NET8` does not retarget these projects.
+- **Security Center SDK**: Installed with the `GSC_SDK` environment variable pointing to its .NET Framework assemblies.
 - **Visual Studio 2022**: Version 17.6 or later for development (must run as Administrator)
 - **Security Center**: Installed and running on your system
 - **Valid Security Center License**: All samples include the development SDK certificate
 
+
+## Building modern .NET plugins
+
+Choose your `ServerModule` target framework based on the Security Center version deployed on the role server. .NET 8 hosting is available from Security Center 5.13, and .NET 10 hosting is available from Security Center 5.14.1. A `ClientModule` must target .NET Framework because Security Desk and Config Tool host it in-process.
+
+### Security Center 5.14 and later
+
+Deploy and register the `ServerModule` on each server assigned to the role. Add a `ClientModule` on the workstations only if your integration provides a Security Desk or Config Tool extension.
+
+### Security Center 5.13
+
+For a modern .NET `ServerModule`, also deploy and register a .NET Framework `Client` discovery assembly on the role server. This assembly allows Security Center to discover the plugin type. A `ClientModule` for user interface extensions is a separate component.
+
+For project setup, migration steps, and the custom-privilege deployment exception, see [Building .NET plugins](https://github.com/Genetec/DAP/wiki/plugin-sdk-net8) and [Deploying plugins and Workspace modules](https://github.com/Genetec/DAP/wiki/plugin-sdk-deployment).
 
 ## Creating a Plugin
 

--- a/Samples/Workspace SDK/README.md
+++ b/Samples/Workspace SDK/README.md
@@ -5,7 +5,7 @@ This guide demonstrates how to build a Workspace module for Security Center. Wor
 
 ## Prerequisites
 
-- **.NET Framework 4.8.1**: The Workspace SDK only supports the .NET Framework; it does not support .NET 8 yet.  
+- **.NET Framework 4.8.1 targeting pack**: The samples target `net481`. Workspace modules must target .NET Framework because Security Desk and Config Tool host them in-process on .NET Framework.
 - **Security Center SDK**: Installed with `GSC_SDK` environment variable configured
 - **Visual Studio 2022**: Version 17.6 or later for development
 - **Security Center**: Client applications (Security Desk and Config Tool) installed
@@ -239,7 +239,7 @@ This is a Security Center-specific feature configured during module registration
 **Example:**
 ```xml
 <PluginInstallation>
-  <Version>1</Version>
+  <Version>2</Version>
   <Configuration>
     <Item Key="Enabled" Value="True" />
     <Item Key="ClientModule" Value="C:\MyModule\MyModule.dll" />
@@ -334,7 +334,7 @@ REG ADD &quot;HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Genetec\Security Center\Pl
 </Target>
 ```
 
-**Important**: This registry-based approach is for development only. For production deployment, Security Center 5.13+ uses XML configuration files instead of registry entries. See the separate "Deploying Plugins and Workspace Modules" guide for complete production deployment instructions.
+Register the `ClientModule` on each workstation that runs your extension in Security Desk or Config Tool. For deployment on Security Center 5.13 or later, use a `*.Plugin.xml` file as described in [Deploying plugins and Workspace modules](https://github.com/Genetec/DAP/wiki/plugin-sdk-deployment). Registry registration remains available for development and older deployments.
 
 The post-build registration writes to `HKEY_LOCAL_MACHINE`, so it requires administrative privileges. Run Visual Studio as an administrator when building samples that include this post-build target.
 


### PR DESCRIPTION
The READMEs mixed the samples' configured target frameworks with SDK runtime support and plugin host requirements. Clarify those distinctions across all eight READMEs, including the Media SDK requirement for .NET Framework and separate plugin deployment guidance for Security Center 5.13 and 5.14+.

Update build prerequisites, project-folder instructions, and wiki links. Clarify that the GWP desktop sample is standalone and that user secrets are for development.